### PR TITLE
Allow Failed installments to not be reprocessed

### DIFF
--- a/apidoc/docs/configuration.md
+++ b/apidoc/docs/configuration.md
@@ -11,7 +11,8 @@ behaviour of the gem:
 SolidusSubscriptions::Config.default_gateway = my_gateway
 
 # Defines how long the system will wait before allowing a failed installment to
-# be reprocessed by the `Processor`
+# be reprocessed by the `Processor`. Set to nil to stop reprocessing failedx
+# installments
 SolidusSubscriptions::Config.reprocessing_interval = 1.days
 
 # Maximum number of times a user can skip their subscription before it

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -119,6 +119,7 @@ module SolidusSubscriptions
     end
 
     def next_actionable_date
+      return if Config.reprocessing_interval.nil?
       (DateTime.current + Config.reprocessing_interval).beginning_of_minute
     end
   end

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -90,6 +90,22 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
       actionable_date = installment.reload.actionable_date
       expect(actionable_date).to eq expected_date
     end
+
+    context 'the reprocessing interval is set to nil' do
+      around do |e|
+        interval, SolidusSubscriptions::Config.reprocessing_interval = [SolidusSubscriptions::Config.reprocessing_interval, nil]
+
+        e.run
+
+        SolidusSubscriptions::Config.reprocessing_interval = interval
+      end
+
+      it 'does not advance the installment actionable_date' do
+        subject
+        actionable_date = installment.reload.actionable_date
+        expect(actionable_date).to be_nil
+      end
+    end
   end
 
   describe '#unfulfilled?' do


### PR DESCRIPTION
By default, when installments fail to be processed for any reason, they
are rescheduled to be reprocessed at a later date.

If the Config.reprocessing_interval field is set to nil, the installment
will not be reprocessed if it fails