### PR TITLE
Only load permitted attributes once

### DIFF
--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -1,6 +1,9 @@
 module SolidusSubscriptions
   class Engine < Rails::Engine
     require 'spree/core'
+    require 'solidus_subscriptions/permitted_attributes'
+    require 'solidus_subscriptions/config'
+    require 'solidus_subscriptions/processor'
 
     isolate_namespace SolidusSubscriptions
     engine_name 'solidus_subscriptions'
@@ -11,10 +14,12 @@ module SolidusSubscriptions
     end
 
     config.autoload_paths << config.root.join('app', 'jobs')
-    config.autoload_paths << config.root.join('lib')
 
-    initializer 'solidus_subscriptions.configs', before: "spree.register.payment_methods" do
-      require 'solidus_subscriptions/config'
+    initializer 'configure spree subcription permitted attributes', after: 'require subscription lib helpers' do
+      PermittedAttributes.update_spree_permiteed_attributes
+    end
+
+    initializer 'solidus_subscriptions.configs', before: "require subscription lib helpers" do
     end
 
     initializer 'register_subscription_promotion_rule', after: 'spree.promo.register.promotion.rules' do |app|
@@ -39,7 +44,6 @@ module SolidusSubscriptions
       end
 
       Spree::Ability.register_ability(SolidusSubscriptions::Ability)
-      PermittedAttributes.update_spree_permiteed_attributes
     end
 
     config.to_prepare(&method(:activate).to_proc)


### PR DESCRIPTION
Previous Behaviour:
The to_prepare block was reloading the permitted attributes module. This
resulted in the subscription parameters being appended to the spree
premitted attributes multiple times.

New behaviour:
Do not auto load the lib directory
Only load the permitted attributes once during the initalization process