### PR TITLE
Fix/the broken admin

### DIFF
--- a/app/models/solidus_subscriptions/interval.rb
+++ b/app/models/solidus_subscriptions/interval.rb
@@ -12,8 +12,6 @@ module SolidusSubscriptions
         month: 2,
         year: 3
       }
-
-      base.validates :interval_length, numericality: { greater_than: 0 }
     end
 
     # Calculates the number of seconds in the interval.

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -28,7 +28,8 @@ module SolidusSubscriptions
     )
 
     validates :subscribable_id, presence: :true
-    validates :quantity, :interval_length, numericality: { greater_than: 0 }
+    validates :quantity, numericality: { greater_than: 0 }
+    validates :interval_length, numericality: { greater_than: 0 }, unless: -> { subscription }
 
     before_update :update_actionable_date_if_interval_changed
 
@@ -71,7 +72,7 @@ module SolidusSubscriptions
     end
 
     def update_actionable_date_if_interval_changed
-      if subscription && (interval_length_changed? || interval_units_changed?)
+      if persisted? && subscription && (interval_length_changed? || interval_units_changed?)
         base_date = if subscription.installments.any?
           subscription.installments.last.created_at
         else

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -8,13 +8,14 @@ module SolidusSubscriptions
     PROCESSING_STATES = [:pending, :failed, :success]
 
     belongs_to :user, class_name: Spree.user_class
-    has_many :line_items, class_name: 'SolidusSubscriptions::LineItem'
+    has_many :line_items, class_name: 'SolidusSubscriptions::LineItem', inverse_of: :subscription
     has_many :installments, class_name: 'SolidusSubscriptions::Installment'
     belongs_to :store, class_name: 'Spree::Store'
     belongs_to :shipping_address, class_name: 'Spree::Address'
 
     validates :user, presence: :true
     validates :skip_count, :successive_skip_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
+    validates :interval_length, numericality: { greater_than: 0 }
 
     accepts_nested_attributes_for :line_items, :shipping_address
 

--- a/app/views/spree/admin/subscriptions/_form.html.erb
+++ b/app/views/spree/admin/subscriptions/_form.html.erb
@@ -15,48 +15,48 @@
     <% end %>
   </fieldset>
 
-  <%= f.fields_for :line_item, @line_item do |lf| %>
-    <div class="row">
-      <%= content_tag :div, class: "field alpha three columns" do %>
-        <%= f.label :actionable_date %>
-        <%= f.text_field :actionable_date, class: "fullwidth datepicker" %>
-      <% end %>
+  <div class="row">
+    <%= content_tag :div, class: "field alpha three columns" do %>
+      <%= f.label :actionable_date %>
+      <%= f.text_field :actionable_date, class: "fullwidth datepicker" %>
+    <% end %>
 
-      <div class='field three columns'>
-        <%= lf.label :inverval_length %>
-        <%= lf.number_field :interval_length, class: "fullwidth" %>
-      </div>
+    <div class='field three columns'>
+      <%= f.label :inverval_length %>
+      <%= f.number_field :interval_length, class: "fullwidth" %>
+    </div>
 
-      <div class='field three columns'>
-        <%= lf.label :interval_units %>
-        <%
-          unit_values = SolidusSubscriptions::LineItem.interval_units.keys
-          units = unit_values.map do |unit|
-            [
-              unit,
-              SolidusSubscriptions::LineItem.human_attribute_name("interval_units.#{ unit }")
-            ]
-          end
-        %>
+    <div class='field three columns'>
+      <%= f.label :interval_units %>
+      <%
+        unit_values = SolidusSubscriptions::LineItem.interval_units.keys
+        units = unit_values.map do |unit|
+          [
+            unit,
+            SolidusSubscriptions::LineItem.human_attribute_name("interval_units.#{ unit }")
+          ]
+        end
+      %>
 
-        <div>
-          <% units.each_with_index do |(value, name), i| %>
-            <div>
-              <%= lf.label :interval_units, for: "interval_units_#{ value }", class: 'fullwidth' do %>
-                <%= lf.radio_button :interval_units, value, id: "interval_units_#{ value }" %>
-                <%= name %>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-      </div>
-
-      <div class="field omega three columns">
-        <%= lf.label :end_date %>
-        <%= lf.date_field :end_date, class: "required", class: "fullwidth" %>
+      <div>
+        <% units.each_with_index do |(value, name), i| %>
+          <div>
+            <%= f.label :interval_units, for: "interval_units_#{ value }", class: 'fullwidth' do %>
+              <%= f.radio_button :interval_units, value, id: "interval_units_#{ value }" %>
+              <%= name %>
+            <% end %>
+          </div>
+        <% end %>
       </div>
     </div>
 
+    <div class="field omega three columns">
+      <%= f.label :end_date %>
+      <%= f.date_field :end_date, class: "required fullwidth" %>
+    </div>
+  </div>
+
+  <%= f.fields_for :line_items do |lf| %>
     <fieldset class='no-border-bottom'>
       <legend><%= t('.subscription_line_item') %></legend>
 

--- a/app/views/spree/admin/subscriptions/_legacy_form.html.erb
+++ b/app/views/spree/admin/subscriptions/_legacy_form.html.erb
@@ -1,0 +1,81 @@
+<% new ||= false %>
+
+<fieldset class="no-border-top">
+  <fieldset class="index no-border-bottom">
+    <legend><%= t('.subscription') %></legend>
+
+    <% if new %>
+      <div class="row">
+        <div class="field twelve columns">
+          <%= f.label :user_id, Spree.t(:user), class: "required" %>
+          <%= f.collection_select :user_id,  Spree::User.all, :id, :email, {}, class: "select2 fullwidth" %>
+        </div>
+
+      </div>
+    <% end %>
+  </fieldset>
+
+  <%= f.fields_for :line_item, @line_item do |lf| %>
+    <div class="row">
+      <%= content_tag :div, class: "field alpha three columns" do %>
+        <%= f.label :actionable_date %>
+        <%= f.text_field :actionable_date, class: "fullwidth datepicker" %>
+      <% end %>
+
+      <div class='field three columns'>
+        <%= lf.label :inverval_length %>
+        <%= lf.number_field :interval_length, class: "fullwidth" %>
+      </div>
+
+      <div class='field three columns'>
+        <%= lf.label :interval_units %>
+        <%
+          unit_values = SolidusSubscriptions::LineItem.interval_units.keys
+          units = unit_values.map do |unit|
+            [
+              unit,
+              SolidusSubscriptions::LineItem.human_attribute_name("interval_units.#{ unit }")
+            ]
+          end
+        %>
+
+        <div>
+          <% units.each_with_index do |(value, name), i| %>
+            <div>
+              <%= lf.label :interval_units, for: "interval_units_#{ value }", class: 'fullwidth' do %>
+                <%= lf.radio_button :interval_units, value, id: "interval_units_#{ value }" %>
+                <%= name %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="field omega three columns">
+        <%= lf.label :end_date %>
+        <%= lf.date_field :end_date, class: "required", class: "fullwidth" %>
+      </div>
+    </div>
+
+    <fieldset class='no-border-bottom'>
+      <legend><%= t('.subscription_line_item') %></legend>
+
+      <div class="row">
+        <div class='field alpha two columns'>
+          <%= lf.label :quantity %>
+          <%= lf.number_field :quantity, min: 1, class: "fullwidth" %>
+        </div>
+
+        <div class="field columns ten omega">
+          <%= lf.label :subscribable_id %>
+          <%= lf.collection_select :subscribable_id, Spree::Variant.where(subscribable: true), :id, :pretty_name, {}, { class: "fullwidth select2" } %>
+        </div>
+      </div>
+
+    </fieldset>
+  <% end %>
+
+  <div class="filter-actions" data-hook='buttons'>
+    <%= f.button type: :submit %>
+  </div>
+</fieldset>

--- a/app/views/spree/admin/subscriptions/_legacy_sidebar.html.erb
+++ b/app/views/spree/admin/subscriptions/_legacy_sidebar.html.erb
@@ -1,0 +1,28 @@
+<dl>
+  <dt><%= t('.customer') %></dt>
+  <dd>
+    <%= link_to @subscription.user.email, spree.admin_user_path(@subscription.user) %>
+  </dd>
+
+  <dt><%= t('.status') %></dt>
+  <dd>
+    <%= content_tag :span, class: "state #{ @subscription.state }" do %>
+      <%= @subscription.human_state_name %>
+    <% end %>
+  </dd>
+
+  <dt><%= t('.fulfillment_status') %></dt>
+  <dd>
+    <%= content_tag :span,  class: "state #{ @subscription.processing_state }" do %>
+      <%= @subscription.class.human_attribute_name("processing_state.#{ @subscription.processing_state }") %>
+    <% end %>
+  </dd>
+
+  <dt><%= t('.revenue') %></dt>
+  <dd>
+    <%= @subscription.line_item.dummy_line_item.try(:display_price) %>
+  </dd>
+
+  <dt><%= t('.interval') %></dt>
+  <dd><%= @subscription.line_item.interval.inspect %></dd>
+</dl>

--- a/app/views/spree/admin/subscriptions/edit.html.erb
+++ b/app/views/spree/admin/subscriptions/edit.html.erb
@@ -9,34 +9,7 @@
 <% end %>
 
 <% content_for :sidebar do %>
-  <dl>
-    <dt><%= t('.customer') %></dt>
-    <dd>
-      <%= link_to @subscription.user.email, spree.admin_user_path(@subscription.user) %>
-    </dd>
-
-    <dt><%= t('.status') %></dt>
-    <dd>
-      <%= content_tag :span, class: "state #{ @subscription.state }" do %>
-        <%= @subscription.human_state_name %>
-      <% end %>
-    </dd>
-
-    <dt><%= t('.fulfillment_status') %></dt>
-    <dd>
-      <%= content_tag :span,  class: "state #{ @subscription.processing_state }" do %>
-        <%= @subscription.class.human_attribute_name("processing_state.#{ @subscription.processing_state }") %>
-      <% end %>
-    </dd>
-
-    <dt><%= t('.revenue') %></dt>
-    <dd>
-      <%= @subscription.line_item.dummy_line_item.try(:display_price) %>
-    </dd>
-
-    <dt><%= t('.interval') %></dt>
-    <dd><%= @subscription.line_item.interval.inspect %></dd>
-  </dl>
+  <%= render 'spree/admin/subscriptions/legacy_sidebar' if @subscription.respond_to?(:line_item) %>
 <% end %>
 
 <%= form_for @subscription, url: spree.admin_subscription_path(@subscription) do |f| %>

--- a/app/views/spree/admin/subscriptions/edit.html.erb
+++ b/app/views/spree/admin/subscriptions/edit.html.erb
@@ -13,5 +13,9 @@
 <% end %>
 
 <%= form_for @subscription, url: spree.admin_subscription_path(@subscription) do |f| %>
-  <%= render "form", f: f %>
+  <% if f.object.respond_to?(:line_items) %>
+    <%= render "form", f: f %>
+  <% else %>
+    <%= render "legacy_form",  f: f %>
+  <% end %>
 <% end %>

--- a/spec/controllers/spree/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/spree/admin/subscriptions_controller_spec.rb
@@ -1,40 +1,49 @@
 require 'rails_helper'
-RSpec.describe Spree::Admin::SubscriptionsController, type: :controller do
-  routes { Spree::Core::Engine.routes }
+RSpec.describe Spree::Admin::SubscriptionsController, type: :request do
+  extend Spree::TestingSupport::AuthorizationHelpers::Request
   stub_authorization!
 
   describe 'get /admin/subscriptions' do
-    subject { get :index }
+    subject do
+      get spree.admin_subscriptions_path
+      response
+    end
 
     it { is_expected.to be_successful }
   end
 
   describe 'GET :new' do
-    subject { get :new }
+    subject do
+      get spree.new_admin_subscription_path
+      response
+    end
 
     it { is_expected.to be_successful }
   end
 
   describe 'GET :edit' do
-    subject { get :edit, params: { id: subscription.id } }
+    subject do
+      get spree.edit_admin_subscription_path(subscription)
+      response
+    end
+
     let(:subscription) { create :subscription, :actionable }
 
     it { is_expected.to be_successful }
   end
 
   describe 'PUT :update' do
-    subject { put :update, params: subscription_params }
+    subject { put spree.admin_subscription_path(subscription), params: subscription_params }
 
     let(:expected_date) { DateTime.parse('2001/11/12') }
     let(:subscription) { create :subscription, :actionable }
     let(:subscription_params) do
       {
-        id: subscription.id,
         subscription: { actionable_date: expected_date }
       }
     end
 
-    it { is_expected.to redirect_to admin_subscriptions_path }
+    it { is_expected.to redirect_to spree.admin_subscriptions_path }
 
     it 'updates the subscription attributes', :aggregate_failures do
       expect { subject }.to change { subscription.reload.actionable_date }.to expected_date
@@ -42,11 +51,11 @@ RSpec.describe Spree::Admin::SubscriptionsController, type: :controller do
   end
 
   describe 'POST cancel' do
-    subject { delete :cancel, params: { id: subscription.id } }
+    subject { delete spree.cancel_admin_subscription_path(subscription) }
     context 'the subscription can be canceled' do
       let(:subscription) { create :subscription, :actionable }
 
-      it { is_expected.to redirect_to admin_subscriptions_path }
+      it { is_expected.to redirect_to spree.admin_subscriptions_path }
 
       it 'has a message' do
         subject
@@ -61,7 +70,7 @@ RSpec.describe Spree::Admin::SubscriptionsController, type: :controller do
     context 'the subscription cannot be canceled' do
       let(:subscription) { create :subscription, :canceled }
 
-      it { is_expected.to redirect_to admin_subscriptions_path }
+      it { is_expected.to redirect_to spree.admin_subscriptions_path }
 
       it 'has a message' do
         subject
@@ -75,12 +84,12 @@ RSpec.describe Spree::Admin::SubscriptionsController, type: :controller do
   end
 
   describe 'POST activate' do
-    subject { post :activate, params: { id: subscription.id } }
+    subject { post spree.activate_admin_subscription_path(subscription) }
 
     context 'the subscription can be activated' do
       let(:subscription) { create :subscription, :canceled, :with_line_item }
 
-      it { is_expected.to redirect_to admin_subscriptions_path }
+      it { is_expected.to redirect_to spree.admin_subscriptions_path }
 
       it 'has a message' do
         subject
@@ -95,7 +104,7 @@ RSpec.describe Spree::Admin::SubscriptionsController, type: :controller do
     context 'the subscription cannot be activated' do
       let(:subscription) { create :subscription, :actionable, :with_line_item }
 
-      it { is_expected.to redirect_to admin_subscriptions_path }
+      it { is_expected.to redirect_to spree.admin_subscriptions_path }
 
       it 'has a message' do
         subject
@@ -109,12 +118,12 @@ RSpec.describe Spree::Admin::SubscriptionsController, type: :controller do
   end
 
   describe 'POST skip' do
-    subject { post :skip, params: { id: subscription.id } }
+    subject { post spree.skip_admin_subscription_path(subscription) }
 
     let(:subscription) { create :subscription, :actionable, :with_line_item }
     let!(:expected_date) { subscription.next_actionable_date }
 
-    it { is_expected.to redirect_to admin_subscriptions_path }
+    it { is_expected.to redirect_to spree.admin_subscriptions_path }
 
     it 'has a message' do
       subject

--- a/spec/controllers/spree/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/spree/admin/subscriptions_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-
 RSpec.describe Spree::Admin::SubscriptionsController, type: :controller do
   routes { Spree::Core::Engine.routes }
   stub_authorization!
@@ -14,6 +13,32 @@ RSpec.describe Spree::Admin::SubscriptionsController, type: :controller do
     subject { get :new }
 
     it { is_expected.to be_successful }
+  end
+
+  describe 'GET :edit' do
+    subject { get :edit, params: { id: subscription.id } }
+    let(:subscription) { create :subscription, :actionable }
+
+    it { is_expected.to be_successful }
+  end
+
+  describe 'PUT :update' do
+    subject { put :update, params: subscription_params }
+
+    let(:expected_date) { DateTime.parse('2001/11/12') }
+    let(:subscription) { create :subscription, :actionable }
+    let(:subscription_params) do
+      {
+        id: subscription.id,
+        subscription: { actionable_date: expected_date }
+      }
+    end
+
+    it { is_expected.to redirect_to admin_subscriptions_path }
+
+    it 'updates the subscription attributes', :aggregate_failures do
+      expect { subject }.to change { subscription.reload.actionable_date }.to expected_date
+    end
   end
 
   describe 'POST cancel' do


### PR DESCRIPTION
Problem: 
The change from Subscription -> Line Item being a one to one relationship to a one to many relationship broke the views for the admin area to be able to update subscriptions.

Solution: 
- Move the legacy form to its own partial 
- Update the admin subscriptions form to support multiple line items
- conditionally render the subscription form fields based on the supported behaviour of the chosen version of the subscriptions gem
