### PR TITLE
Subs track their own interval now

### DIFF
--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -1,5 +1,4 @@
-# The LineItem class is responsible for associating Line items to subscriptions.
-# It tracks the following values:
+# The LineItem class is responsible for associating Line items to subscriptions.  # It tracks the following values:
 #
 # [Spree::LineItem] :spree_line_item The spree object which created this instance
 #
@@ -53,6 +52,10 @@ module SolidusSubscriptions
       li.freeze
     end
 
+    def interval
+      subscription.try!(:interval) || super
+    end
+
     private
 
     # Get a placeholder order for calculating the values of future
@@ -68,7 +71,7 @@ module SolidusSubscriptions
     # A place holder for calculating dynamic values needed to display in the cart
     # it is frozen and cannot be saved
     def dummy_subscription
-      Subscription.new(line_items: [dup]).freeze
+      Subscription.new(line_items: [dup], interval_length: interval_length, interval_units: interval_units).freeze
     end
 
     def update_actionable_date_if_interval_changed

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -23,8 +23,8 @@ module SolidusSubscriptions
     # The following methods are delegated to the associated
     # SolidusSubscriptions::LineItem
     #
-    # :interval, :quantity, :subscribable_id, :end_date
-    delegate :interval, :quantity, :subscribable_id, :end_date, to: :line_item
+    # :quantity, :subscribable_id
+    delegate :quantity, :subscribable_id, to: :line_item
 
     # Find all subscriptions that are "actionable"; that is, ones that have an
     # actionable_date in the past and are not invalid or canceled.


### PR DESCRIPTION
There is no need to delegate this to the associated line item. This
value will be persisted on the subscription once an order is completed
(or the subscription is created through the administrative interface)