### PR TITLE
Authorize subscriptions admin sidebar link

### DIFF
--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -33,7 +33,8 @@ module SolidusSubscriptions
         config.menu_items << config.class::MenuItem.new(
           [:subscriptions],
           'repeat',
-          url: :admin_subscriptions_path
+          url: :admin_subscriptions_path,
+          condition: ->{ can?(:admin, SolidusSubscriptions::Subscription) }
         )
       end
     end


### PR DESCRIPTION
Only show the admin sidebar link if the user is authorized to see it.

Before:
The link to the subscriptions area of the subscriptions administrative
area would be displayed on the admin login screen.
Clicking this link without authenticating would redirect the user to the
log in page

After:
The link to the subscriptions area of the admin is hidden until after
the user authenticates