### PR TITLE
Small UI change to canceling in the admin

### DIFF
--- a/app/views/spree/admin/solidus_subscriptions/subscriptions/_subscription.html.erb
+++ b/app/views/spree/admin/solidus_subscriptions/subscriptions/_subscription.html.erb
@@ -27,7 +27,7 @@
     <% if subscription.state_events.include?(:cancel) %>
       <%=
         link_to_with_icon(
-          :pause,
+          :stop,
           t('.cancel'),
           spree.cancel_admin_subscription_path(subscription),
           no_text: true,

--- a/app/views/spree/admin/solidus_subscriptions/subscriptions/_subscription.html.erb
+++ b/app/views/spree/admin/solidus_subscriptions/subscriptions/_subscription.html.erb
@@ -31,7 +31,8 @@
           t('.cancel'),
           spree.cancel_admin_subscription_path(subscription),
           no_text: true,
-          method: :delete
+          method: :delete,
+          data: { confirm: t('.cancel_alert') }
         )
       %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
         subscriptions:
           subscription:
             cancel: Cancel
+            cancel_alert: "Are you sure you want to cancel this subscription?"
             activate: Activate
             skip: Skip One
 


### PR DESCRIPTION
It's always felt off that the cancel button was a "pause" icon and happened without confirmation. This updates it to be a "stop" icon (restarting is a "play" icon), which seems to be the right level of destructive to me. More than pause, less than trash can.

Also adds a confirmation dialog. Although the subscription can easily be restarted, it's conceivable that a store hooks in a cancelation email and it would be nice to double check that they actually want to cancel. This also follows the Solidus Orders admin, which confirms via a dialog (it can also be restarted).

This is all very much just opinion.