### PR TITLE
Add ffaker dependency to gemspec

### DIFF
--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl'
+  s.add_development_dependency 'ffaker'
   s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
ffaker was removed as a runtime dependency of Solidus. As of right now,
this removal is only on Solidus master (but it is slated for v2.4).

Even though this extension does not use ffaker directly, Solidus
complains that its factories require the library and so the tests fail
without this.

PR removing ffaker from Solidus:
https://github.com/solidusio/solidus/pull/2163

**EDIT**: The tests actually fail because of `require ffaker` in `spec/spec_helper.rb`. But even removing this line will cause the tests to fail in the way described above.