### PR TITLE
Use Spree::UserClassHandle

### DIFF
--- a/app/decorators/spree/users/have_many_subscriptions.rb
+++ b/app/decorators/spree/users/have_many_subscriptions.rb
@@ -1,7 +1,7 @@
 # Spree::Users maintain a list of the subscriptions associated with them
 module Spree
   module Users
-    module HaveManySubscritptions
+    module HaveManySubscriptions
       def self.prepended(base)
         base.has_many(
           :subscriptions,
@@ -16,5 +16,5 @@ module Spree
 end
 
 Spree::UserClassHandle.new.to_s.constantize.prepend(
-  Spree::Users::HaveManySubscritptions
+  Spree::Users::HaveManySubscriptions
 )

--- a/app/decorators/spree/users/have_many_subscriptions.rb
+++ b/app/decorators/spree/users/have_many_subscriptions.rb
@@ -15,4 +15,6 @@ module Spree
   end
 end
 
-Spree.user_class.prepend(Spree::Users::HaveManySubscritptions)
+Spree::UserClassHandle.new.to_s.constantize.prepend(
+  Spree::Users::HaveManySubscritptions
+)

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -7,7 +7,7 @@ module SolidusSubscriptions
 
     PROCESSING_STATES = [:pending, :failed, :success]
 
-    belongs_to :user, class_name: Spree.user_class
+    belongs_to :user, class_name: Spree::UserClassHandle.new
     has_many :line_items, class_name: 'SolidusSubscriptions::LineItem', inverse_of: :subscription
     has_many :installments, class_name: 'SolidusSubscriptions::Installment'
     belongs_to :store, class_name: 'Spree::Store'

--- a/spec/overrides/spree/users/have_many_subscriptions.rb
+++ b/spec/overrides/spree/users/have_many_subscriptions.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Spree::Users::HaveManySubscritptions, type: :model do
+RSpec.describe Spree::Users::HaveManySubscriptions, type: :model do
   subject { Spree::User.new }
 
   it { is_expected.to have_many :subscriptions }


### PR DESCRIPTION
This stops a deprecation in Rails. Rails 5.2 will raise an
ArgumentError if `class_name` is given a class. Instead Rails wants it
to be given a string.

Spree::UserClassHandle is a placeholder for the name of
Spree.user_class.

Check out `solidus/core/app/models/spree/user_class_handle.rb` for more
information.