### PR TITLE
Fix deprecation for `Order#update!`

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
@@ -16,7 +16,7 @@ class SolidusSubscriptions::Api::V1::LineItemsController < Spree::Api::BaseContr
     return render json: {}, status: 400 if @line_item.order.complete?
 
     @line_item.destroy!
-    @line_item.order.update!
+    @line_item.order.recalculate
 
     render json: @line_item.to_json
   end

--- a/app/models/solidus_subscriptions/checkout.rb
+++ b/app/models/solidus_subscriptions/checkout.rb
@@ -65,7 +65,7 @@ module SolidusSubscriptions
     private
 
     def checkout
-      order.update!
+      order.recalculate
       apply_promotions
 
       order.checkout_steps[0...-1].each do

--- a/app/models/solidus_subscriptions/checkout.rb
+++ b/app/models/solidus_subscriptions/checkout.rb
@@ -1,6 +1,6 @@
 # This class takes a collection of installments and populates a new spree
 # order with the correct contents based on the subscriptions associated to the
-# intallments. This is to group together subscriptions being
+# installments. This is to group together subscriptions being
 # processed on the same day for a specific user
 module SolidusSubscriptions
   class Checkout

--- a/app/models/solidus_subscriptions/subscription_line_item_builder.rb
+++ b/app/models/solidus_subscriptions/subscription_line_item_builder.rb
@@ -9,7 +9,7 @@ module SolidusSubscriptions
 
       # Rerun the promotion handler to pickup subscription promotions
       Spree::PromotionHandler::Cart.new(line_item.order).activate
-      line_item.order.update!
+      line_item.order.recalculate
     end
 
     def subscription_params


### PR DESCRIPTION
Solidus wants everyone to use `Order#recalculate` instead.

https://github.com/solidusio/solidus/blob/master/core/app/models/spree/order.rb#L261-L268