### PR TITLE
Fix typos in comments

### DIFF
--- a/app/decorators/spree/orders/finalize_creates_subscriptions.rb
+++ b/app/decorators/spree/orders/finalize_creates_subscriptions.rb
@@ -1,5 +1,5 @@
 # Once an order is finalized its subscriptions line items should be converted
-# into active subscritptions. This hooks into Spree::Order#finalize! and
+# into active subscriptions. This hooks into Spree::Order#finalize! and
 # passes all subscription_line_items present on the order to the Subscription
 # generator which will build and persist the subscriptions
 module Spree

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -1,6 +1,6 @@
-# This class represents a single iteration of a subscription. It is fulfulled
-# by a conmpleted order and maintains an association which tracks all attempts
-# successful or othewise at fulfulling this installment
+# This class represents a single iteration of a subscription. It is fulfilled
+# by a completed order and maintains an association which tracks all attempts
+# successful or otherwise at fulfilling this installment
 module SolidusSubscriptions
   class Installment < ActiveRecord::Base
     has_many :details, class_name: 'SolidusSubscriptions::InstallmentDetail'

--- a/app/models/solidus_subscriptions/installment_detail.rb
+++ b/app/models/solidus_subscriptions/installment_detail.rb
@@ -1,5 +1,5 @@
 # This class represents a single attempt to fulfill an installment. It will
-# indicate the result of that attept.
+# indicate the result of that attempt.
 module SolidusSubscriptions
   class InstallmentDetail < ActiveRecord::Base
     belongs_to(

--- a/app/models/solidus_subscriptions/interval.rb
+++ b/app/models/solidus_subscriptions/interval.rb
@@ -1,5 +1,5 @@
 # This module is intended to be included into any active record
-# modle which needs to be aware of how intervals and stored and
+# model which needs to be aware of how intervals are stored and
 # calculated in the db.
 #
 # Base models must have the following fields: interval_length (integer) and interval_units (integer)

--- a/app/models/solidus_subscriptions/line_item_builder.rb
+++ b/app/models/solidus_subscriptions/line_item_builder.rb
@@ -28,7 +28,7 @@ module SolidusSubscriptions
         Spree::LineItem.new(variant: variant, quantity: subscription_line_item.quantity)
       end
 
-      # Either all line items for an installment are fullfilled or none are
+      # Either all line items for an installment are fulfilled or none are
       line_items.all? ? line_items : []
     end
 

--- a/app/models/solidus_subscriptions/order_builder.rb
+++ b/app/models/solidus_subscriptions/order_builder.rb
@@ -4,7 +4,7 @@ module SolidusSubscriptions
   class OrderBuilder
     attr_reader :order
 
-    # Get a new instance of a OrderBuilder
+    # Get a new instance of an OrderBuilder
     #
     # @param order [Spree::Order] The order to be built
     #
@@ -13,7 +13,7 @@ module SolidusSubscriptions
       @order = order
     end
 
-    # Add line items for to an order. If the order already
+    # Add line items to an order. If the order already
     # has a line item for a given variant_id, update the quantity. Otherwise
     # add the line item to the order.
     #

--- a/app/models/solidus_subscriptions/out_of_stock_dispatcher.rb
+++ b/app/models/solidus_subscriptions/out_of_stock_dispatcher.rb
@@ -1,4 +1,4 @@
-# This service class is intented to provide callback behaviour to handle
+# This service class is intended to provide callback behaviour to handle
 # the case where an installment cannot be processed due to lack of stock.
 module SolidusSubscriptions
   class OutOfStockDispatcher < Dispatcher

--- a/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
+++ b/app/models/solidus_subscriptions/payment_failed_dispatcher.rb
@@ -1,4 +1,4 @@
-# This service class is intented to provide callback behaviour to handle
+# This service class is intended to provide callback behaviour to handle
 # the case where a subscription order cannot be processed because a payment
 # failed
 module SolidusSubscriptions

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -1,4 +1,4 @@
-# The subscription class is responsable for grouping together the
+# The subscription class is responsible for grouping together the
 # information required for the system to place a subscriptions order on
 # behalf of a specific user.
 module SolidusSubscriptions
@@ -34,7 +34,7 @@ module SolidusSubscriptions
     end)
 
     # Find subscriptions based on their processing state. This state is not a
-    # model attrubute.
+    # model attribute.
     #
     # @param state [Symbol] One of :pending, :success, or failed
     #
@@ -109,7 +109,7 @@ module SolidusSubscriptions
 
     # This method determines if a subscription may be canceled. Canceled
     # subcriptions will not be processed. By default subscriptions may always be
-    # canceled. If this method is overriden to return false, the subscription
+    # canceled. If this method is overridden to return false, the subscription
     # will be moved to the :pending_cancellation state until it is canceled
     # again and this condition is true.
     #
@@ -123,7 +123,7 @@ module SolidusSubscriptions
     #
     # If a user cancels this subscription less than 10 days before it will
     # be processed the subscription will be bumped into the
-    # :pending_cancellation state instead of being canceled. Susbcriptions
+    # :pending_cancellation state instead of being canceled. Subscriptions
     # pending cancellation will still be processed.
     def can_be_canceled?
       return true if actionable_date.nil?
@@ -182,7 +182,7 @@ module SolidusSubscriptions
     end
 
     # The state of the last attempt to process an installment associated to
-    # this subscrtipion
+    # this subscription
     #
     # @return [String] pending if the no installments have been processed,
     #   failed if the last installment has not been fulfilled and, success

--- a/app/models/solidus_subscriptions/subscription_promotion_rule.rb
+++ b/app/models/solidus_subscriptions/subscription_promotion_rule.rb
@@ -25,7 +25,7 @@ module SolidusSubscriptions
     end
 
     # Certain actions create adjustments on line items. In this case, only
-    # line items with associated subscription_line_itms are eligible to be
+    # line items with associated subscription_line_items are eligible to be
     # adjusted. Will only return true # if :line_item has an associated
     # subscription.
     #

--- a/app/models/solidus_subscriptions/success_dispatcher.rb
+++ b/app/models/solidus_subscriptions/success_dispatcher.rb
@@ -1,4 +1,4 @@
-# This service class is intented to provide callback behaviour to handle
+# This service class is intended to provide callback behaviour to handle
 # an installment successfully being processed
 module SolidusSubscriptions
   class SuccessDispatcher < Dispatcher


### PR DESCRIPTION
Just over here picking on the little things.

I am going to go over the documentation next and at that point will consider regenerating the YARD docs. It looks like it has been awhile since they have been generated.