### PR TITLE
Change static factory attrs to dynamic

### DIFF
--- a/lib/solidus_subscriptions/testing_support/factories/installment_detail_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/installment_detail_factory.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :installment_detail, class: 'SolidusSubscriptions::InstallmentDetail' do
     installment
 
-    trait(:success) { success true }
+    trait(:success) {
+      success { true }
+    }
   end
 end

--- a/lib/solidus_subscriptions/testing_support/factories/installment_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/installment_factory.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :installment, class: 'SolidusSubscriptions::Installment' do
-    transient { subscription_traits [] }
+    transient {
+      subscription_traits { [] }
+    }
     subscription { build :subscription, :with_line_item, *subscription_traits }
 
     trait :failed do

--- a/lib/solidus_subscriptions/testing_support/factories/line_item_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/line_item_factory.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :subscription_line_item, class: 'SolidusSubscriptions::LineItem' do
     subscribable_id { create(:variant, subscribable: true).id }
-    quantity 1
-    interval_length 1
-    interval_units :month
+    quantity { 1 }
+    interval_length { 1 }
+    interval_units { :month }
 
     association :spree_line_item, factory: :line_item
 
     trait :with_subscription do
       transient do
-        subscription_traits []
+        subscription_traits { [] }
       end
 
       subscription { build :subscription, *subscription_traits }

--- a/lib/solidus_subscriptions/testing_support/factories/spree/line_item_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/spree/line_item_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.modify do
   factory :line_item do
     trait :with_subscription_line_items do
       transient do
-        n_subscription_line_items 1
+        n_subscription_line_items { 1 }
       end
 
       subscription_line_items do

--- a/lib/solidus_subscriptions/testing_support/factories/spree/order_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/spree/order_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.modify do
   factory :order do
     trait :with_subscription_line_items do
       transient do
-        n_line_items 1
+        n_line_items { 1 }
       end
 
       line_items do

--- a/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :subscription, class: 'SolidusSubscriptions::Subscription' do
     store
-    interval_length 1
-    interval_units :month
+    interval_length { 1 }
+    interval_units { :month }
 
     user do
       new_user = create(:user, :subscription_user)
@@ -14,7 +14,7 @@ FactoryBot.define do
 
     trait :with_line_item do
       transient do
-        line_item_traits []
+        line_item_traits { [] }
       end
 
       line_items { build_list :subscription_line_item, 1, *line_item_traits }
@@ -39,7 +39,11 @@ FactoryBot.define do
       state { 'pending_cancellation' }
     end
 
-    trait(:canceled) { state 'canceled' }
-    trait(:inactive) { state 'inactive' }
+    trait(:canceled) {
+      state { 'canceled' }
+    }
+    trait(:inactive) {
+      state { 'inactive' }
+    }
   end
 end


### PR DESCRIPTION
FactoryBot 5.0 will no longer support static factory attributes, so we
need to update our factories in advance to silence the deprecation
warnings.