### PR TITLE
Fix factory girl dependency for Solidus < 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,23 @@ gem 'solidus', github: 'solidusio/solidus', branch: branch
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise', '~> 1.0'
 
-if branch != 'master' && branch < 'v2.0'
-  gem "rails_test_params_backport", group: :test
+group :test do
+  if branch != 'master' && branch < 'v2.0'
+    gem "rails_test_params_backport"
+  end
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
 end
 
-gem 'pg', '~> 0.21'
-gem 'mysql2'
+if ENV['DB'] == 'mysql'
+  gem 'mysql2', '~> 0.4.10'
+else
+  gem 'pg', '~> 0.21'
+end
+
 gem 'listen'
 
 gemspec


### PR DESCRIPTION
We need to load a factory_bot version that has factory_girl in it
to support Solidus versions < 2.5

This change also includes conditional logic for the database
interface gems.