### PR TITLE
Change api url in documentation

### DIFF
--- a/apidoc/api/v1/subscription_line_items.md
+++ b/apidoc/api/v1/subscription_line_items.md
@@ -2,7 +2,7 @@
 SolidusSubscriptions::LineItems are analogous to Spree::LineItem. They indicate
 the details of a subscription prior to a purchase being made.
 
-## PATCH `subscriptions/api/v1/line_item/:id`
+## PATCH `/subscriptions/api/v1/line_item/:id`
 *Authentication Required*
 
 Update the details of a specific SolidusSubscriptions::LineItem. e.g. From the

--- a/apidoc/api/v1/subscription_line_items.md
+++ b/apidoc/api/v1/subscription_line_items.md
@@ -2,7 +2,7 @@
 SolidusSubscriptions::LineItems are analogous to Spree::LineItem. They indicate
 the details of a subscription prior to a purchase being made.
 
-## PATCH `/api/v1/line_item/:id`
+## PATCH `subscriptions/api/v1/line_item/:id`
 *Authentication Required*
 
 Update the details of a specific SolidusSubscriptions::LineItem. e.g. From the

--- a/apidoc/api/v1/subscriptions.md
+++ b/apidoc/api/v1/subscriptions.md
@@ -1,6 +1,6 @@
 # Subscriptions
 
-## POST `subscriptions/api/v1/subscriptions/:id`
+## POST `/subscriptions/api/v1/subscriptions/:id`
 *Authentication Required*
 
 Mark a subscription as canceled, by updating its state and removing its
@@ -30,7 +30,7 @@ HTTP/1.1 200 OK
 }
 ```
 
-## PATCH `subscriptions/api/v1/subscriptions/:id`
+## PATCH `/subscriptions/api/v1/subscriptions/:id`
 *Authentication Required*
 
 Make changes to the Subscription object or the subscription line item object
@@ -76,7 +76,7 @@ HTTP/1.1 200 OK
 
 ```
 
-## POST `subscriptions/api/v1/subscriptions/:id/skip`
+## POST `/subscriptions/api/v1/subscriptions/:id/skip`
 *Authentication Required*
 
 Advance the subscription by one extra interval, thereby skipping the next

--- a/apidoc/api/v1/subscriptions.md
+++ b/apidoc/api/v1/subscriptions.md
@@ -1,6 +1,6 @@
 # Subscriptions
 
-## POST `/api/v1/subscriptions/:id`
+## POST `subscriptions/api/v1/subscriptions/:id`
 *Authentication Required*
 
 Mark a subscription as canceled, by updating its state and removing its
@@ -30,7 +30,7 @@ HTTP/1.1 200 OK
 }
 ```
 
-## PATCH `/api/v1/subscriptions/:id`
+## PATCH `subscriptions/api/v1/subscriptions/:id`
 *Authentication Required*
 
 Make changes to the Subscription object or the subscription line item object
@@ -76,7 +76,7 @@ HTTP/1.1 200 OK
 
 ```
 
-## POST `/api/v1/subscriptions/:id/skip`
+## POST `subscriptions/api/v1/subscriptions/:id/skip`
 *Authentication Required*
 
 Advance the subscription by one extra interval, thereby skipping the next


### PR DESCRIPTION
Because of the way we mount this extension, we have to specify 'subscription' before the url (https://github.com/solidusio-contrib/solidus_subscriptions/blob/b2275c71fed698e9d33c89e428dd094a1338a5e9/config/routes.rb#L16). We should consider changing the way this is mounted but for now I have edited the documentation.