### PR TITLE
Update rubocop to fix vulnerability CVE-2017-8418

### DIFF
--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-activemodel-mocks'
   s.add_development_dependency 'rspec-rails', '~> 3.5'
-  s.add_development_dependency 'rubocop', '0.37.2'
+  s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'shoulda-matchers', '~> 3.1'


### PR DESCRIPTION
RuboCop 0.48.1 and earlier does not use `/tmp` in safe way, allowing local users to exploit this to tamper with cache files belonging to other users.

See [CVE-2017-8418](https://nvd.nist.gov/vuln/detail/CVE-2017-8418) for details.