### PR TITLE
Fix broken factories associations

### DIFF
--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'shoulda-matchers', '~> 3.1'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'versioncake'
   s.add_development_dependency 'yard'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 Dir[File.join(File.dirname(__FILE__), 'helpers/**/*.rb')].each { |f| require f }
 
+FactoryBot.use_parent_strategy = false
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 


### PR DESCRIPTION
FactoryBot v5.0 defaults `use_parent_strategy` to true, which builds (rather than create) associations, which was causing several specs to fail.

This PR also addresses an issue with SQLite (see commit ea118a2 for details)