### PR TITLE
Fix deprecated call to `SolidusSupport.solidus_gem_version`

### DIFF
--- a/app/models/solidus_subscriptions/checkout.rb
+++ b/app/models/solidus_subscriptions/checkout.rb
@@ -118,7 +118,7 @@ module SolidusSubscriptions
     end
 
     def active_card
-      if SolidusSupport.solidus_gem_version < Gem::Version.new("2.2.0")
+      if ::Spree.solidus_gem_version.solidus_gem_version < Gem::Version.new("2.2.0")
         user.credit_cards.default.last
       else
         user.wallet.default_wallet_payment_source.payment_source


### PR DESCRIPTION
Removes a deprecated call to `SolidusSupport.solidus_gem_version` in favor of `Spree.solidus_gem_version`.