### PR TITLE
Fix unsupported `around(:all)` RSpec configuration

### DIFF
--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
       )
     end
 
-    around(:all) do |e|
+    around do |e|
       successive_skip_limit = SolidusSubscriptions::Config.maximum_successive_skips
       total_skip_limit = SolidusSubscriptions::Config.maximum_total_skips
 


### PR DESCRIPTION
Turns an `around(:all)` into `around`. `around(:all)` is not really supported by RSpec and is converted into `around(:example)` internally.