### PR TITLE
Add store field to subscription creation UI

### DIFF
--- a/app/views/spree/admin/subscriptions/_form.html.erb
+++ b/app/views/spree/admin/subscriptions/_form.html.erb
@@ -47,6 +47,11 @@
       <%= f.label :end_date %>
       <%= f.text_field :end_date, class: "fullwidth datepicker" %>
     </div>
+
+    <div class="field">
+      <%= f.label :store_ids, plural_resource_name(Spree::Store) %>
+      <%= f.collection_select :store_id, Spree::Store.all, :id, :name, {}, class: 'fullwidth select2' %>
+    </div>
   </div>
 
   <%= f.fields_for :line_items do |lf| %>


### PR DESCRIPTION
Adds a missing "Store" field in the subscription creation form, which is required for subscriptions. On the frontend, the store is set automatically from the store of the order, but on the backend it needs to be specified manually because subscriptions are not generated from an order.