### PR TITLE
Add github_changelog_generator configuration

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,2 @@
+issues=false
+exclude-labels=infrastructure


### PR DESCRIPTION
Adds a sensible configuration for github_changelog_generator that excludes issues and infrastructure PRs.