### PR TITLE
Allow admins to remove subscription line items

### DIFF
--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -65,6 +65,10 @@ module Spree
       def model_class
         ::SolidusSubscriptions::Subscription
       end
+
+      def location_after_save
+        edit_object_url(@subscription)
+      end
     end
   end
 end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -18,7 +18,7 @@ module SolidusSubscriptions
     validates :interval_length, numericality: { greater_than: 0 }
 
     accepts_nested_attributes_for :shipping_address
-    accepts_nested_attributes_for :line_items, allow_destroy: true
+    accepts_nested_attributes_for :line_items, allow_destroy: true, reject_if: -> (p) { p[:quantity].blank? }
 
     # The following methods are delegated to the associated
     # SolidusSubscriptions::LineItem

--- a/app/views/spree/admin/subscriptions/_form.html.erb
+++ b/app/views/spree/admin/subscriptions/_form.html.erb
@@ -63,11 +63,20 @@
           </div>
         </div>
 
-        <div class="col-2">
+        <div class="col-1">
           <div class="field">
             <%= lf.label :quantity %>
-            <%= lf.number_field :quantity, min: 1, class: "fullwidth" %>
+            <%= lf.number_field :quantity, min: 1, class: "form-control fullwidth" %>
           </div>
+        </div>
+
+        <div class="col-1">
+          <% if lf.object.persisted? %>
+            <div class="field align-center">
+              <%= lf.label :_destroy %>
+              <%= lf.check_box :_destroy, class: "form-control" %>
+            </div>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
           skip: Skip One
           new_subscription: New Subscription
         edit:
-          title: Edit a Susbcription
+          title: Edit a Subscription
           customer: Customer
           status: Status
           fulfillment_status: Fulfillment Status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,8 @@ en:
         pending: new
         success: success
         failed: failure
+      solidus_subscriptions/line_item:
+        _destroy: Remove?
 
     errors:
       models:

--- a/spec/controllers/spree/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/spree/admin/subscriptions_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Spree::Admin::SubscriptionsController, type: :request do
       }
     end
 
-    it { is_expected.to redirect_to spree.admin_subscriptions_path }
+    it { is_expected.to redirect_to spree.edit_admin_subscription_path(subscription) }
 
     it 'updates the subscription attributes', :aggregate_failures do
       expect { subject }.to change { subscription.reload.actionable_date }.to expected_date


### PR DESCRIPTION
Adds a "Remove?" checkbox to subscription line items in the subscription edit page in the backend. If checked, this will remove the line item from the subscription.