### PR TITLE
Add shipping address to backend subscription form

### DIFF
--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -16,10 +16,12 @@ module Spree
 
       def new
         @subscription.line_items.new
+        @subscription.build_shipping_address unless @subscription.shipping_address
       end
 
       def edit
         @subscription.line_items.new
+        @subscription.build_shipping_address unless @subscription.shipping_address
       end
 
       def cancel

--- a/app/views/spree/admin/subscriptions/_form.html.erb
+++ b/app/views/spree/admin/subscriptions/_form.html.erb
@@ -83,12 +83,10 @@
         </div>
 
         <div class="col-1">
-          <% if lf.object.persisted? %>
-            <div class="field align-center">
-              <%= lf.label :_destroy %>
-              <%= lf.check_box :_destroy, class: "form-control" %>
-            </div>
-          <% end %>
+          <div class="field align-center">
+            <%= lf.label :_destroy %>
+            <%= lf.check_box :_destroy, class: "form-control", disabled: lf.object.new_record? %>
+          </div>
         </div>
       </div>
     <% end %>

--- a/app/views/spree/admin/subscriptions/_form.html.erb
+++ b/app/views/spree/admin/subscriptions/_form.html.erb
@@ -51,6 +51,18 @@
     </div>
   </div>
 
+  <div class="js-customer-details">
+    <fieldset class="no-border-bottom">
+      <legend>Shipping Address</legend>
+
+      <div class="js-shipping-address">
+        <%= f.fields_for :shipping_address do |sa_form| %>
+          <%= render partial: 'spree/admin/shared/address_form', locals: { f: sa_form, type: "shipping" } %>
+        <% end %>
+      </div>
+    </fieldset>
+  </div>
+
   <fieldset class="no-border-bottom">
     <legend><%= t('.subscription_line_items') %></legend>
 


### PR DESCRIPTION
Subscriptions require a valid address in order to be processed, so we must include the address in the subscription form in the backend.