### PR TITLE
Add subscription details to backend

### DIFF
--- a/app/controllers/spree/admin/installments_controller.rb
+++ b/app/controllers/spree/admin/installments_controller.rb
@@ -1,0 +1,23 @@
+module Spree
+  module Admin
+    class InstallmentsController < ResourceController
+      belongs_to 'subscription', model_class: SolidusSubscriptions::Subscription
+
+      skip_before_action :load_resource, only: :index
+
+      def index
+        @search = collection.ransack(params[:q])
+
+        @installments = @search.result(distinct: true).
+          page(params[:page]).
+          per(params[:per_page] || Spree::Config[:orders_per_page])
+      end
+
+      private
+
+      def model_class
+        ::SolidusSubscriptions::Installment
+      end
+    end
+  end
+end

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -36,7 +36,7 @@ module Spree
           notice = @subscription.errors.full_messages.to_sentence
         end
 
-        redirect_to spree.admin_subscriptions_path, notice: notice
+        redirect_back(fallback_location: spree.admin_subscriptions_path, notice: notice)
       end
 
       def activate
@@ -48,7 +48,7 @@ module Spree
           notice = @subscription.errors.full_messages.to_sentence
         end
 
-        redirect_to spree.admin_subscriptions_path, notice: notice
+        redirect_back(fallback_location: spree.admin_subscriptions_path, notice: notice)
       end
 
       def skip
@@ -59,7 +59,7 @@ module Spree
           date: @subscription.actionable_date
         )
 
-        redirect_to spree.admin_subscriptions_path, notice: notice
+        redirect_back(fallback_location: spree.admin_subscriptions_path, notice: notice)
       end
 
       private

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -95,6 +95,13 @@ module SolidusSubscriptions
       details.where(success: true).exists?
     end
 
+    # Returns the state of this fulfillment
+    #
+    # @return [Symbol] :fulfilled/:unfulfilled
+    def state
+      fulfilled? ? :fulfilled : :unfulfilled
+    end
+
     # Mark this installment as having a failed payment
     #
     # @param order [Spree::Order] The order generated for this processing

--- a/app/views/spree/admin/installments/_state_pill.html.erb
+++ b/app/views/spree/admin/installments/_state_pill.html.erb
@@ -1,0 +1,8 @@
+<% state_class = {
+    fulfilled: 'active',
+    unfulfilled: 'error',
+}[installment.state.to_sym] %>
+
+<span class="pill pill-<%= state_class %>">
+  <%= SolidusSubscriptions::Installment.human_attribute_name("state.#{installment.state}") %>
+</span>

--- a/app/views/spree/admin/installments/index.html.erb
+++ b/app/views/spree/admin/installments/index.html.erb
@@ -1,0 +1,35 @@
+<% content_for(:page_title, t('.title')) %>
+
+<%= render 'spree/admin/shared/subscription_breadcrumbs', subscription: @subscription %>
+<%= render 'spree/admin/shared/subscription_sidebar', subscription: @subscription %>
+<%= render 'spree/admin/shared/subscription_tabs', current: :installments %>
+
+<fieldset class="no-border-bottom">
+  <legend><%= t('spree.admin.installments.index.title') %></legend>
+
+  <%= paginate @installments, theme: 'solidus_admin' %>
+
+  <table id="listing_installments" class="index">
+    <thead>
+      <tr data-hook="admin_installments_index_headers">
+        <th><%= sort_link(@search, :actionable_date, SolidusSubscriptions::Installment.human_attribute_name(:actionable_date)) %></th>
+        <th><%= sort_link(@search, :created_at, SolidusSubscriptions::Installment.human_attribute_name(:created_at)) %></th>
+        <th><%= SolidusSubscriptions::Installment.human_attribute_name(:fulfilled) %></th>
+        <th data-hook="admin_installments_index_header_actions" class="actions"></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @installments.each do |installment| %>
+        <tr>
+          <td><%= l(installment.actionable_date.to_date) if installment.actionable_date %></td>
+          <td><%= l(installment.created_at.to_date) %></td>
+          <td><%= render 'state_pill', installment: installment %></td>
+          <td class="actions"></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @installments, theme: 'solidus_admin' %>
+</fieldset>

--- a/app/views/spree/admin/installments/index.html.erb
+++ b/app/views/spree/admin/installments/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'spree/admin/shared/subscription_breadcrumbs', subscription: @subscription %>
 <%= render 'spree/admin/shared/subscription_sidebar', subscription: @subscription %>
-<%= render 'spree/admin/shared/subscription_tabs', current: :installments %>
+<%= render 'spree/admin/shared/subscription_tabs', current: :installments, subscription: @subscription %>
 <%= render 'spree/admin/shared/subscription_actions', subscription: @subscription %>
 
 <fieldset class="no-border-bottom">

--- a/app/views/spree/admin/installments/index.html.erb
+++ b/app/views/spree/admin/installments/index.html.erb
@@ -3,6 +3,7 @@
 <%= render 'spree/admin/shared/subscription_breadcrumbs', subscription: @subscription %>
 <%= render 'spree/admin/shared/subscription_sidebar', subscription: @subscription %>
 <%= render 'spree/admin/shared/subscription_tabs', current: :installments %>
+<%= render 'spree/admin/shared/subscription_actions', subscription: @subscription %>
 
 <fieldset class="no-border-bottom">
   <legend><%= t('spree.admin.installments.index.title') %></legend>

--- a/app/views/spree/admin/shared/_subscription_actions.html.erb
+++ b/app/views/spree/admin/shared/_subscription_actions.html.erb
@@ -1,0 +1,35 @@
+<% content_for :page_actions do %>
+  <% if subscription.state_events.include?(:cancel) %>
+    <%=
+      link_to(
+          t('spree.admin.subscriptions.actions.cancel'),
+          spree.cancel_admin_subscription_path(subscription),
+          method: :delete,
+          data: { confirm: t('spree.admin.subscriptions.actions.cancel_alert') },
+          class: 'btn btn-primary'
+      )
+    %>
+  <% end %>
+
+  <% if subscription.state_events.include?(:activate) %>
+    <%=
+      link_to(
+          t('spree.admin.subscriptions.actions.activate'),
+          spree.activate_admin_subscription_path(subscription),
+          method: :post,
+          class: 'btn btn-primary',
+      )
+    %>
+  <% end %>
+
+  <% if subscription.active? %>
+    <%=
+      link_to(
+          t('spree.admin.subscriptions.actions.skip'),
+          spree.skip_admin_subscription_path(subscription),
+          method: :post,
+          class: 'btn btn-default',
+      )
+    %>
+  <% end %>
+<% end %>

--- a/app/views/spree/admin/shared/_subscription_breadcrumbs.html.erb
+++ b/app/views/spree/admin/shared/_subscription_breadcrumbs.html.erb
@@ -1,0 +1,4 @@
+<% admin_breadcrumb(
+       link_to(plural_resource_name(SolidusSubscriptions::Subscription), admin_subscriptions_path),
+       link_to("#{subscription.id}", edit_admin_subscription_path(subscription))
+   ) %>

--- a/app/views/spree/admin/shared/_subscription_sidebar.html.erb
+++ b/app/views/spree/admin/shared/_subscription_sidebar.html.erb
@@ -1,0 +1,18 @@
+<% content_for :sidebar_title do %>
+  <%= t("spree.admin.subscriptions.edit.sidebar") %>
+<% end %>
+
+<% content_for :sidebar do %>
+  <nav class="menu">
+    <fieldset class="no-border-top no-border-bottom" data-hook="admin_user_lifetime_stats">
+      <dl id="user-lifetime-stats">
+        <dt><%= SolidusSubscriptions::Subscription.human_attribute_name(:created_at) %>:</dt>
+        <dd><%= l(subscription.created_at.to_date) %></dd>
+        <dt><%= SolidusSubscriptions::Subscription.human_attribute_name(:state) %>:</dt>
+        <dd><%= render 'spree/admin/subscriptions/state_pill', subscription: subscription %></dd>
+        <dt><%= SolidusSubscriptions::Subscription.human_attribute_name(:processing_state) %>:</dt>
+        <dd><%= render 'spree/admin/subscriptions/processing_state_pill', subscription: subscription %></dd>
+      </dl>
+    </fieldset>
+  </nav>
+<% end %>

--- a/app/views/spree/admin/shared/_subscription_tabs.html.erb
+++ b/app/views/spree/admin/shared/_subscription_tabs.html.erb
@@ -4,6 +4,9 @@
       <li<%== ' class="active"' if current == :details %>>
         <%= link_to t("spree.admin.subscriptions.edit.details"), spree.edit_admin_subscription_path(@subscription) %>
       </li>
+      <li<%== ' class="active"' if current == :installments %>>
+        <%= link_to t("spree.admin.subscriptions.edit.installments"), spree.admin_subscription_installments_path(@subscription) %>
+      </li>
     </ul>
   </nav>
 <% end %>

--- a/app/views/spree/admin/shared/_subscription_tabs.html.erb
+++ b/app/views/spree/admin/shared/_subscription_tabs.html.erb
@@ -1,0 +1,9 @@
+<% content_for :tabs do %>
+  <nav>
+    <ul class='tabs' data-hook="admin_subscription_tab_options">
+      <li<%== ' class="active"' if current == :details %>>
+        <%= link_to t("spree.admin.subscriptions.edit.details"), spree.edit_admin_subscription_path(@subscription) %>
+      </li>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/spree/admin/shared/_subscription_tabs.html.erb
+++ b/app/views/spree/admin/shared/_subscription_tabs.html.erb
@@ -2,10 +2,10 @@
   <nav>
     <ul class='tabs' data-hook="admin_subscription_tab_options">
       <li<%== ' class="active"' if current == :details %>>
-        <%= link_to t("spree.admin.subscriptions.edit.details"), spree.edit_admin_subscription_path(@subscription) %>
+        <%= link_to t("spree.admin.subscriptions.edit.details"), spree.edit_admin_subscription_path(subscription) %>
       </li>
       <li<%== ' class="active"' if current == :installments %>>
-        <%= link_to t("spree.admin.subscriptions.edit.installments"), spree.admin_subscription_installments_path(@subscription) %>
+        <%= link_to t("spree.admin.subscriptions.edit.installments"), spree.admin_subscription_installments_path(subscription) %>
       </li>
     </ul>
   </nav>

--- a/app/views/spree/admin/subscriptions/_form.html.erb
+++ b/app/views/spree/admin/subscriptions/_form.html.erb
@@ -1,81 +1,83 @@
-<fieldset data-hook="new_subscription">
-  <legend><%= t('.subscription') %></legend>
+<div data-hook="new_subscription">
+  <fieldset class="no-border-bottom">
+    <legend><%= t('.subscription') %></legend>
 
-  <div data-hook="admin_subscription_form_fields">
-    <% if f.object.new_record? %>
+    <div data-hook="admin_subscription_form_fields">
+      <% if f.object.new_record? %>
+        <div class="field">
+          <%= f.label :user_id, I18n.t('spree.user'), class: "required" %>
+          <%= f.collection_select :user_id,  Spree::User.all, :id, :email, {}, class: "select2 fullwidth" %>
+        </div>
+      <% end %>
+
       <div class="field">
-        <%= f.label :user_id, I18n.t('spree.user'), class: "required" %>
-        <%= f.collection_select :user_id,  Spree::User.all, :id, :email, {}, class: "select2 fullwidth" %>
+        <%= f.label :actionable_date %>
+        <%= f.text_field :actionable_date, class: "form-control fullwidth datepicker" %>
       </div>
-    <% end %>
 
-    <div class="field">
-      <%= f.label :actionable_date %>
-      <%= f.text_field :actionable_date, class: "form-control fullwidth datepicker" %>
-    </div>
+      <div class="row">
+        <div class="col-6">
+          <div class="field">
+            <%= f.label :interval_length %>
+            <%= f.number_field :interval_length, class: "form-control fullwidth" %>
+          </div>
+        </div>
 
-    <div class="row">
-      <div class="col-6">
-        <div class="field">
-          <%= f.label :interval_length %>
-          <%= f.number_field :interval_length, class: "form-control fullwidth" %>
+        <div class="col-6">
+          <div class="field">
+            <%
+              unit_values = SolidusSubscriptions::LineItem.interval_units.keys
+              units = unit_values.map do |unit|
+                [
+                    SolidusSubscriptions::LineItem.human_attribute_name("interval_units.#{unit}"),
+                    unit,
+                ]
+              end
+            %>
+
+            <%= f.label :interval_units %>
+            <%= f.select(:interval_units, units, {}, class: 'fullwidth select2') %>
+          </div>
         </div>
       </div>
 
-      <div class="col-6">
-        <div class="field">
-          <%
-            unit_values = SolidusSubscriptions::LineItem.interval_units.keys
-            units = unit_values.map do |unit|
-              [
-                SolidusSubscriptions::LineItem.human_attribute_name("interval_units.#{unit}"),
-                unit,
-              ]
-            end
-          %>
+      <div class="field">
+        <%= f.label :end_date %>
+        <%= f.text_field :end_date, class: "fullwidth datepicker" %>
+      </div>
 
-          <%= f.label :interval_units %>
-          <%= f.select(:interval_units, units, {}, class: 'fullwidth select2') %>
-        </div>
+      <div class="field">
+        <%= f.label :store_id %>
+        <%= f.collection_select :store_id, Spree::Store.all, :id, :name, {}, class: 'fullwidth select2' %>
       </div>
     </div>
+  </fieldset>
 
-    <div class="field">
-      <%= f.label :end_date %>
-      <%= f.text_field :end_date, class: "fullwidth datepicker" %>
-    </div>
+  <fieldset class="no-border-bottom">
+    <legend>Shipping Address</legend>
 
-    <div class="field">
-      <%= f.label :store_id %>
-      <%= f.collection_select :store_id, Spree::Store.all, :id, :name, {}, class: 'fullwidth select2' %>
-    </div>
-  </div>
-
-  <div class="js-customer-details">
-    <fieldset class="no-border-bottom">
-      <legend>Shipping Address</legend>
-
+    <div class="js-customer-details">
       <div class="js-shipping-address">
         <%= f.fields_for :shipping_address do |sa_form| %>
           <%= render partial: 'spree/admin/shared/address_form', locals: { f: sa_form, type: "shipping" } %>
         <% end %>
       </div>
-    </fieldset>
-  </div>
+    </div>
+  </fieldset>
 
-  <fieldset class="no-border-bottom">
+  <fieldset>
     <legend><%= t('.subscription_line_items') %></legend>
 
     <%= f.fields_for :line_items do |lf| %>
       <div class="row">
-        <div class="col-10">
+        <div class="col-9">
           <div class="field">
             <%= lf.label :subscribable_id %>
             <%= lf.collection_select :subscribable_id, Spree::Variant.where(subscribable: true), :id, :pretty_name, {}, { class: "fullwidth select2" } %>
           </div>
         </div>
 
-        <div class="col-1">
+        <div class="col-2">
           <div class="field">
             <%= lf.label :quantity %>
             <%= lf.number_field :quantity, min: 1, class: "form-control fullwidth" %>
@@ -90,11 +92,11 @@
         </div>
       </div>
     <% end %>
-  </fieldset>
 
-  <% if f.object.new_record? %>
-    <%= render partial: 'spree/admin/shared/new_resource_links' %>
-  <% else %>
-    <%= render partial: 'spree/admin/shared/edit_resource_links' %>
-  <% end %>
-</fieldset>
+    <% if f.object.new_record? %>
+      <%= render partial: 'spree/admin/shared/new_resource_links' %>
+    <% else %>
+      <%= render partial: 'spree/admin/shared/edit_resource_links' %>
+    <% end %>
+  </fieldset>
+</div>

--- a/app/views/spree/admin/subscriptions/_form.html.erb
+++ b/app/views/spree/admin/subscriptions/_form.html.erb
@@ -70,7 +70,7 @@
 
     <%= f.fields_for :line_items do |lf| %>
       <div class="row">
-        <div class="col-9">
+        <div class="col-8">
           <div class="field">
             <%= lf.label :subscribable_id %>
             <%= lf.collection_select :subscribable_id, Spree::Variant.where(subscribable: true), :id, :pretty_name, {}, { class: "fullwidth select2" } %>
@@ -84,7 +84,7 @@
           </div>
         </div>
 
-        <div class="col-1">
+        <div class="col-2">
           <div class="field align-center">
             <%= lf.label :_destroy %>
             <%= lf.check_box :_destroy, class: "form-control", disabled: lf.object.new_record? %>

--- a/app/views/spree/admin/subscriptions/_processing_state_pill.html.erb
+++ b/app/views/spree/admin/subscriptions/_processing_state_pill.html.erb
@@ -1,0 +1,9 @@
+<% state_class = {
+    success: 'active',
+    failed: 'error',
+    pending: 'inactive',
+}[subscription.processing_state.to_sym] %>
+
+<span class="pill pill-<%= state_class %>">
+  <%= subscription.class.human_attribute_name("processing_state.#{subscription.processing_state}") %>
+</span>

--- a/app/views/spree/admin/subscriptions/_state_pill.html.erb
+++ b/app/views/spree/admin/subscriptions/_state_pill.html.erb
@@ -1,0 +1,10 @@
+<% state_class = {
+    active: 'active',
+    canceled: 'error',
+    pending_cancellation: 'warning',
+    inactive: 'inactive',
+}[subscription.state.to_sym] %>
+
+<span class="pill pill-<%= state_class %>">
+  <%= subscription.human_state_name %>
+</span>

--- a/app/views/spree/admin/subscriptions/edit.html.erb
+++ b/app/views/spree/admin/subscriptions/edit.html.erb
@@ -1,8 +1,6 @@
 <% content_for(:page_title) { t('.title') } %>
 
-<% content_for :sidebar_title do %>
-  Details
-<% end %>
+<%= render 'spree/admin/shared/subscription_sidebar', subscription: @subscription %>
 
 <%= form_for @subscription, url: spree.admin_subscription_path(@subscription) do |f| %>
   <%= render "form", f: f %>

--- a/app/views/spree/admin/subscriptions/edit.html.erb
+++ b/app/views/spree/admin/subscriptions/edit.html.erb
@@ -2,6 +2,7 @@
 
 <%= render 'spree/admin/shared/subscription_breadcrumbs', subscription: @subscription %>
 <%= render 'spree/admin/shared/subscription_sidebar', subscription: @subscription %>
+<%= render 'spree/admin/shared/subscription_tabs', current: :details %>
 
 <%= form_for @subscription, url: spree.admin_subscription_path(@subscription) do |f| %>
   <%= render "form", f: f %>

--- a/app/views/spree/admin/subscriptions/edit.html.erb
+++ b/app/views/spree/admin/subscriptions/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'spree/admin/shared/subscription_breadcrumbs', subscription: @subscription %>
 <%= render 'spree/admin/shared/subscription_sidebar', subscription: @subscription %>
-<%= render 'spree/admin/shared/subscription_tabs', current: :details %>
+<%= render 'spree/admin/shared/subscription_tabs', current: :details, subscription: @subscription %>
 <%= render 'spree/admin/shared/subscription_actions', subscription: @subscription %>
 
 <%= form_for @subscription, url: spree.admin_subscription_path(@subscription) do |f| %>

--- a/app/views/spree/admin/subscriptions/edit.html.erb
+++ b/app/views/spree/admin/subscriptions/edit.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:page_title) { t('.title') } %>
 
+<%= render 'spree/admin/shared/subscription_breadcrumbs', subscription: @subscription %>
 <%= render 'spree/admin/shared/subscription_sidebar', subscription: @subscription %>
 
 <%= form_for @subscription, url: spree.admin_subscription_path(@subscription) do |f| %>

--- a/app/views/spree/admin/subscriptions/edit.html.erb
+++ b/app/views/spree/admin/subscriptions/edit.html.erb
@@ -3,6 +3,7 @@
 <%= render 'spree/admin/shared/subscription_breadcrumbs', subscription: @subscription %>
 <%= render 'spree/admin/shared/subscription_sidebar', subscription: @subscription %>
 <%= render 'spree/admin/shared/subscription_tabs', current: :details %>
+<%= render 'spree/admin/shared/subscription_actions', subscription: @subscription %>
 
 <%= form_for @subscription, url: spree.admin_subscription_path(@subscription) do |f| %>
   <%= render "form", f: f %>

--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -128,11 +128,11 @@
               <%=
                 link_to_with_icon(
                     :stop,
-                    t('.cancel'),
+                    t('spree.admin.subscriptions.actions.cancel'),
                     spree.cancel_admin_subscription_path(subscription),
                     no_text: true,
                     method: :delete,
-                    data: { confirm: t('.cancel_alert') }
+                    data: { confirm: t('spree.admin.subscriptions.actions.cancel_alert') }
                 )
               %>
             <% end %>
@@ -141,7 +141,7 @@
               <%=
                 link_to_with_icon(
                     :play,
-                    t('.activate'),
+                    t('spree.admin.subscriptions.actions.activate'),
                     spree.activate_admin_subscription_path(subscription),
                     no_text: true,
                     method: :post
@@ -153,7 +153,7 @@
               <%=
                 link_to_with_icon(
                     :'fast-forward',
-                    t('.skip'),
+                    t('spree.admin.subscriptions.actions.skip'),
                     spree.skip_admin_subscription_path(subscription),
                     no_text: true,
                     method: :post

--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -121,12 +121,8 @@
           <td><%= link_to subscription.user.email, admin_user_path(subscription.user) %></td>
           <td><%= subscription.actionable_date ? l(subscription.actionable_date.to_date) : '-' %></td>
           <td><%= subscription.interval.inspect %></td>
-          <td><%= content_tag :span, subscription.human_state_name, class: "state #{ subscription.state }" %></td>
-          <td>
-            <span class="state <%= subscription.processing_state %>">
-              <%= subscription.class.human_attribute_name("processing_state.#{subscription.processing_state}") %>
-            </span>
-          </td>
+          <td><%= render 'state_pill', subscription: subscription %></td>
+          <td><%= render 'processing_state_pill', subscription: subscription %></td>
           <td class="actions">
             <% if subscription.state_events.include?(:cancel) %>
               <%=

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
           skip: Skip One
           new_subscription: New Subscription
         edit:
-          title: Edit a Subscription
+          title: Details
           customer: Customer
           status: Status
           fulfillment_status: Fulfillment Status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,11 +23,12 @@ en:
         successfully_canceled: Subsciption Canceled!
         successfully_activated: Subsciption Activated!
         successfully_skipped: Subsciption delayed until %{date}
-        index:
+        actions:
           cancel: Cancel
           cancel_alert: "Are you sure you want to cancel this subscription?"
           activate: Activate
           skip: Skip One
+        index:
           new_subscription: New Subscription
         edit:
           title: Details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
           fulfillment_status: Fulfillment Status
           revenue: Revenue
           interval: Interval
+          sidebar: Status
         new:
           back: Back to Subscriptions List
           title: Create a Susbcription

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
           revenue: Revenue
           interval: Interval
           sidebar: Status
+          details: Details
         new:
           back: Back to Subscriptions List
           title: Create a Susbcription

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
           interval: Interval
           sidebar: Status
           details: Details
+          installments: Installments
         new:
           back: Back to Subscriptions List
           title: Create a Susbcription
@@ -46,6 +47,9 @@ en:
           subscription_line_items: Line Items
       tab:
         subscriptions: Subscriptions
+      installments:
+        index:
+          title: Installments
     promotion_rule_types:
       subscription_promotion_rule:
         name: Subscription
@@ -74,11 +78,20 @@ en:
         failed: failure
       solidus_subscriptions/line_item:
         _destroy: Remove?
-
+      solidus_subscriptions/installment:
+        created_at: Creation date
+        actionable_date: Actionable date
+        state: State
+      solidus_subscriptions/installment/state:
+        fulfilled: Fulfilled
+        unfulfilled: Unfulfilled
     models:
       solidus_subscriptions/subscription:
         one: Subscription
         other: Subscriptions
+      solidus_subscriptions/installment:
+        one: Installment
+        other: Installments
 
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Spree::Core::Engine.routes.draw do
       delete :cancel, on: :member
       post :activate, on: :member
       post :skip, on: :member
+
+      resources :installments, only: [:index, :show]
     end
   end
 end


### PR DESCRIPTION
Makes the subscription page on the backend much more informative by adding a sidebar that displays the subscription's status and actions on the edit page and an entire new section for displaying the installments of a subscription, along with their status.