### PR TITLE
Use subscription's `end_date` in `Subscription#can_be_deactivated?`

### DIFF
--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -9,7 +9,6 @@ module Spree
 
         @subscriptions = @search.result(distinct: true).
           includes(:line_items, :user).
-          joins(:line_items, :user).
           page(params[:page]).
           per(params[:per_page] || Spree::Config[:orders_per_page])
       end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -142,12 +142,12 @@ module SolidusSubscriptions
     # This method determines if a subscription can be deactivated. A deactivated
     # subscription will not be processed. By default a subscription can be
     # deactivated if the end_date defined on
-    # subscription_line_item is less than the current date
+    # the subscription is less than the current date
     # In this case the subscription has been fulfilled and
     # should not be processed again. Subscriptions without an end_date
     # value cannot be deactivated.
     def can_be_deactivated?
-      active? && line_item.end_date && actionable_date > line_item.end_date
+      active? && end_date && actionable_date > end_date
     end
 
     # Get the date after the current actionable_date where this subscription

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SolidusSubscriptions::Processor, :checkout do
       :actionable,
       :with_line_item,
       user: user,
-      line_item_traits: [{ end_date: Date.current.tomorrow }]
+      end_date: Date.current.tomorrow,
     )
   end
 

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -100,16 +100,16 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   describe '#deactivate' do
     subject { subscription.deactivate }
 
-    let(:traits) { [] }
+    let(:attributes) { {} }
     let(:subscription) do
-      create :subscription, :actionable, :with_line_item, line_item_traits: traits do |s|
+      create :subscription, :actionable, :with_line_item, attributes do |s|
         s.installments = build_list(:installment, 2)
       end
     end
 
     context 'the subscription can be deactivated' do
-      let(:traits) do
-        [{ end_date: Date.current.ago(2.days) }]
+      let(:attributes) do
+        { end_date: Date.current.ago(2.days) }
       end
 
       it 'is inactive' do


### PR DESCRIPTION
Uses the end date on the subscription, and not the line item, to determine whether a subscription can be deactivated.

The previous implementation looks like a leftover from times when subscriptions only had one line item and the line item stored information about the subscription's interval and end date. That information has since been moved to the `Subscription` model.

This also allows us to display subscriptions that don't have a line item in the admin list, which was previously impossible because the app would crash since it was calling `#can_be_deactivated?`, which in turn would try to call `#end_date` on a non-existing line item.

Note that this may potentially be a breaking change.