### PR TITLE
Allow setting a billing address on the subscription

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -5,7 +5,7 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
 
   def update
     if @subscription.update(subscription_params)
-      render json: @subscription.to_json(include: [:line_items, :shipping_address])
+      render json: @subscription.to_json(include: [:line_items, :shipping_address, :billing_address])
     else
       render json: @subscription.errors.to_json, status: 422
     end
@@ -36,7 +36,8 @@ class SolidusSubscriptions::Api::V1::SubscriptionsController < Spree::Api::BaseC
   def subscription_params
     params.require(:subscription).permit(
       line_items_attributes: line_item_attributes,
-      shipping_address_attributes: Spree::PermittedAttributes.address_attributes
+      shipping_address_attributes: Spree::PermittedAttributes.address_attributes,
+      billing_address_attributes: Spree::PermittedAttributes.address_attributes,
     )
   end
 

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -14,13 +14,11 @@ module Spree
       end
 
       def new
-        @subscription.line_items.new
-        @subscription.build_shipping_address unless @subscription.shipping_address
+        prepare_form
       end
 
       def edit
-        @subscription.line_items.new
-        @subscription.build_shipping_address unless @subscription.shipping_address
+        prepare_form
       end
 
       def cancel
@@ -69,6 +67,12 @@ module Spree
 
       def location_after_save
         edit_object_url(@subscription)
+      end
+
+      def prepare_form
+        @subscription.line_items.new
+        @subscription.build_shipping_address unless @subscription.shipping_address
+        @subscription.build_billing_address unless @subscription.billing_address
       end
     end
   end

--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -70,6 +70,7 @@ module SolidusSubscriptions
     def dummy_order
       order = spree_line_item ? spree_line_item.order.dup : ::Spree::Order.create
       order.ship_address = subscription.shipping_address || subscription.user.ship_address if subscription
+      order.bill_address = subscription.billing_address || subscription.user.bill_address if subscription
 
       order.freeze
     end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -12,12 +12,14 @@ module SolidusSubscriptions
     has_many :installments, class_name: 'SolidusSubscriptions::Installment'
     belongs_to :store, class_name: '::Spree::Store'
     belongs_to :shipping_address, class_name: '::Spree::Address', optional: true
+    belongs_to :billing_address, class_name: '::Spree::Address', optional: true
 
     validates :user, presence: :true
     validates :skip_count, :successive_skip_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
     validates :interval_length, numericality: { greater_than: 0 }
 
     accepts_nested_attributes_for :shipping_address
+    accepts_nested_attributes_for :billing_address
     accepts_nested_attributes_for :line_items, allow_destroy: true, reject_if: -> (p) { p[:quantity].blank? }
 
     # The following methods are delegated to the associated

--- a/app/services/solidus_subscriptions/checkout.rb
+++ b/app/services/solidus_subscriptions/checkout.rb
@@ -69,8 +69,14 @@ module SolidusSubscriptions
       apply_promotions
 
       order.checkout_steps[0...-1].each do
-        order.ship_address = ship_address if order.state == "address"
-        create_payment if order.state == "payment"
+        case order.state
+        when "address"
+          order.ship_address = ship_address
+          order.bill_address = bill_address
+        when "payment"
+          create_payment
+        end
+
         order.next!
       end
 
@@ -111,6 +117,10 @@ module SolidusSubscriptions
 
     def ship_address
       subscription.shipping_address || user.ship_address
+    end
+
+    def bill_address
+      subscription.billing_address || user.bill_address
     end
 
     def active_card

--- a/app/services/solidus_subscriptions/subscription_generator.rb
+++ b/app/services/solidus_subscriptions/subscription_generator.rb
@@ -24,6 +24,7 @@ module SolidusSubscriptions
         line_items: subscription_line_items,
         store: order.store,
         shipping_address: order.ship_address,
+        billing_address: order.bill_address,
         **configuration.to_h
       }
 

--- a/app/views/spree/admin/subscriptions/_form.html.erb
+++ b/app/views/spree/admin/subscriptions/_form.html.erb
@@ -53,17 +53,32 @@
     </div>
   </fieldset>
 
-  <fieldset class="no-border-bottom">
-    <legend>Shipping Address</legend>
+  <div class="row">
+    <div class="col-6">
+      <fieldset class="no-border-bottom">
+        <legend align="center"><%= t('spree.shipping_address') %></legend>
 
-    <div class="js-customer-details">
-      <div class="js-shipping-address">
-        <%= f.fields_for :shipping_address do |sa_form| %>
-          <%= render partial: 'spree/admin/shared/address_form', locals: { f: sa_form, type: "shipping" } %>
-        <% end %>
-      </div>
+        <div class="js-customer-details">
+          <div class="js-shipping-address">
+            <%= f.fields_for :shipping_address do |sa_form| %>
+              <%= render partial: 'spree/admin/shared/address_form', locals: { f: sa_form, type: "shipping" } %>
+            <% end %>
+          </div>
+        </div>
+      </fieldset>
     </div>
-  </fieldset>
+
+    <div class="col-6">
+      <fieldset class="no-border-bottom">
+        <legend align="center"><%= t('spree.billing_address') %></legend>
+        <div class="js-billing-address">
+          <%= f.fields_for :billing_address do |ba_form| %>
+            <%= render partial: 'spree/admin/shared/address_form', locals: { f: ba_form, type: "billing" } %>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
+  </div>
 
   <fieldset>
     <legend><%= t('.subscription_line_items') %></legend>

--- a/db/migrate/20200617102749_add_billing_address_to_subscriptions.rb
+++ b/db/migrate/20200617102749_add_billing_address_to_subscriptions.rb
@@ -1,0 +1,11 @@
+class AddBillingAddressToSubscriptions < ActiveRecord::Migration[5.2]
+  def change
+    add_reference(
+      :solidus_subscriptions_subscriptions,
+      :billing_address,
+      type: :integer,
+      index: { name: :index_subscription_billing_address_id },
+      foreign_key: { to_table: :spree_addresses }
+    )
+  end
+end

--- a/lib/solidus_subscriptions/factories.rb
+++ b/lib/solidus_subscriptions/factories.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-end

--- a/lib/solidus_subscriptions/processor.rb
+++ b/lib/solidus_subscriptions/processor.rb
@@ -58,7 +58,7 @@ module SolidusSubscriptions
     def build_jobs
       users.map do |user|
         installemts_by_address_and_user = installments(user).group_by do |i|
-          i.subscription.shipping_address_id
+          [i.subscription.shipping_address_id, i.subscription.billing_address_id]
         end
 
         installemts_by_address_and_user.values.each do |grouped_installments|

--- a/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
@@ -20,8 +20,12 @@ FactoryBot.define do
       line_items { build_list :subscription_line_item, 1, *line_item_traits }
     end
 
-    trait :with_address do
+    trait :with_shipping_address do
       association :shipping_address, factory: :address
+    end
+
+    trait :with_billing_address do
+      association :billing_address, factory: :address
     end
 
     trait :actionable do

--- a/reference/solidus_subscriptions.v1.yaml
+++ b/reference/solidus_subscriptions.v1.yaml
@@ -115,18 +115,36 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  subscription:
-                    type: object
+                allOf:
+                  - type: object
                     properties:
-                      line_items_attributes:
+                      line_items:
                         type: array
                         items:
-                          $ref: '#/components/schemas/SubscriptionLineItem'
-                      shipping_address_attributes:
+                          $ref: '#/components/schemas/SubscriptionLineItemOutput'
+                      shipping_address:
                         type: object
+                      billing_address:
+                        type: object
+                  - $ref: '#/components/schemas/SubscriptionOutput'
       operationId: patch-subscriptions-api-v1-subscriptions-id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                subscription:
+                  type: object
+                  properties:
+                    line_items_attributes:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/SubscriptionLineItem'
+                    shipping_address_attributes:
+                      type: object
+                    billing_address_attributes:
+                      type: object
   '/subscriptions/api/v1/subscriptions/{id}/activate':
     parameters:
       - schema:

--- a/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
           state_id: address_state.id,
           phone: '999-999-999',
           zipcode: '10001'
+        },
+        billing_address_attributes: {
+          firstname: 'Ash',
+          lastname: 'Ketchum',
+          address1: '1 Rainbow Road',
+          city: 'Palette Town',
+          country_id: address_country.id,
+          state_id: address_state.id,
+          phone: '999-999-999',
+          zipcode: '10001'
         }
       }
     end

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -107,6 +107,16 @@ RSpec.describe SolidusSubscriptions::Processor, :checkout do
         expect { subject }.to change { Spree::Order.complete.count }.by 2
       end
     end
+
+    context 'the subscriptions have different billing addresses' do
+      let!(:sub_to_different_address) do
+        create(:subscription, :actionable, :with_billing_address, user: user)
+      end
+
+      it 'creates an order for each billing address' do
+        expect { subject }.to change { Spree::Order.complete.count }.by 2
+      end
+    end
   end
 
   describe '.run' do

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe SolidusSubscriptions::Processor, :checkout do
 
     context 'the subscriptions have different shipping addresses' do
       let!(:sub_to_different_address) do
-        create(:subscription, :actionable, :with_address, user: user)
+        create(:subscription, :actionable, :with_shipping_address, user: user)
       end
 
       it 'creates an order for each shipping address' do

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -81,9 +81,9 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
     end
 
     context 'with an associated subscription' do
-      context 'the associated subscription has an address' do
+      context 'the associated subscription has a shipping address' do
         let(:line_item) do
-          create(:subscription_line_item, :with_subscription, subscription_traits: [:with_address])
+          create(:subscription_line_item, :with_subscription, subscription_traits: [:with_shipping_address])
         end
 
         it 'uses the subscription shipping address' do

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -89,13 +89,23 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
         it 'uses the subscription shipping address' do
           expect(subject.order.ship_address).to eq line_item.subscription.shipping_address
         end
+
+        it 'uses the subscription users billing address' do
+          expect(subject.order.bill_address).to eq line_item.subscription.user.bill_address
+        end
       end
 
-      context 'the associated subscription has no address' do
-        let(:line_item) { create(:subscription_line_item, :with_subscription) }
+      context 'the associated subscription has a billing address' do
+        let(:line_item) do
+          create(:subscription_line_item, :with_subscription, subscription_traits: [:with_billing_address])
+        end
 
         it 'uses the subscription users shipping address' do
           expect(subject.order.ship_address).to eq line_item.subscription.user.ship_address
+        end
+
+        it 'uses the subscription billing address' do
+          expect(subject.order.bill_address).to eq line_item.subscription.billing_address
         end
       end
     end

--- a/spec/services/solidus_subscriptions/checkout_spec.rb
+++ b/spec/services/solidus_subscriptions/checkout_spec.rb
@@ -281,6 +281,24 @@ RSpec.describe SolidusSubscriptions::Checkout do
       end
     end
 
+    context 'the subscription has a billing address' do
+      it_behaves_like 'a completed checkout'
+      let(:billing_address) { create :address }
+      let(:installment_traits) do
+        {
+          subscription_traits: [{
+            billing_address: billing_address,
+            user: subscription_user,
+            line_item_traits: [{ spree_line_item: root_order.line_items.first }]
+          }]
+        }
+      end
+
+      it 'ships to the subscription address' do
+        expect(subject.bill_address).to eq billing_address
+      end
+    end
+
     context 'there are multiple associated subscritpion line items' do
       it_behaves_like 'a completed checkout' do
         let(:quantity) { subscription_line_items.length }

--- a/spec/services/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/services/solidus_subscriptions/subscription_generator_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
       expect(subject).to have_attributes(
         user: user,
         shipping_address: subscription_line_item.spree_line_item.order.ship_address,
+        billing_address: subscription_line_item.spree_line_item.order.bill_address,
         interval_length: subscription_line_item.interval_length,
         interval_units: subscription_line_item.interval_units,
         end_date: subscription_line_item.end_date,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,8 @@ require 'solidus_dev_support/rspec/feature_helper'
 # in spec/support/ and its subdirectories.
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
-# Requires factories defined in lib/solidus_subscriptions/factories.rb
-require 'solidus_subscriptions/factories'
+# Requires factories defined in lib/solidus_subscriptions/testing_support/factories.rb
+require 'solidus_subscriptions/testing_support/factories'
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,3 +1,1 @@
-require 'solidus_subscriptions/testing_support/factories'
-
 FactoryBot.use_parent_strategy = false


### PR DESCRIPTION
Closes #117.

Adds the ability for users and admins to set the billing address on their subscription:

- When creating a subscription on the backend, the billing address is set directly on the subscription through the backend UI.
- When creating a subscription on the storefront or via the API, the billing address is copied from the order, just like what happens for the shipping address.

The subscription processing logic has also been adjusted slightly in order to:

- group subscription processing jobs by both shipping and billing address, and
- use either the subscription's billing address or the user's default billing address when processing a subscription.