### PR TITLE
Store payment method and source on subscriptions

### DIFF
--- a/app/assets/javascripts/spree/backend/solidus_subscriptions.js
+++ b/app/assets/javascripts/spree/backend/solidus_subscriptions.js
@@ -1,2 +1,1 @@
-// Placeholder manifest file.
-// the installer will append this file to the app vendored assets here: vendor/assets/javascripts/spree/backend/all.js'
+//= require spree/backend/solidus_subscriptions/edit_subscription_payment

--- a/app/assets/javascripts/spree/backend/solidus_subscriptions/edit_subscription_payment.js
+++ b/app/assets/javascripts/spree/backend/solidus_subscriptions/edit_subscription_payment.js
@@ -1,0 +1,32 @@
+Spree.Views.EditSubscriptionPayment = Backbone.View.extend({
+  initialize: function() {
+    this.onSelectMethod()
+  },
+
+  events: {
+    'change [name="subscription[payment_method_id]"]': 'onSelectMethod',
+  },
+
+  onSelectMethod: function(e) {
+    this.selectedId = parseInt(this.$('select[name="subscription[payment_method_id]"]').val())
+    this.render()
+  },
+
+  render: function() {
+    let selectedId = this.selectedId
+
+    this.$('select[name="subscription[payment_source_id]"] option').each(function () {
+      if (!$(this).data('js-payment-method-id') || parseInt($(this).data('js-payment-method-id')) === selectedId) {
+        $(this).prop('disabled', false)
+      } else {
+        $(this).prop('disabled', true)
+      }
+    })
+  },
+});
+
+Spree.ready(function() {
+  $(".js-edit-subscription-payment").each(function() {
+    new Spree.Views.EditSubscriptionPayment({ el: this })
+  });
+});

--- a/app/services/solidus_subscriptions/checkout.rb
+++ b/app/services/solidus_subscriptions/checkout.rb
@@ -116,22 +116,26 @@ module SolidusSubscriptions
     end
 
     def ship_address
-      subscription.shipping_address || user.ship_address
+      subscription.shipping_address_to_use
     end
 
     def bill_address
-      subscription.billing_address || user.bill_address
+      subscription.billing_address_to_use
     end
 
-    def active_card
-      user.wallet.default_wallet_payment_source.payment_source
+    def payment_source
+      subscription.payment_source_to_use
+    end
+
+    def payment_method
+      subscription.payment_method_to_use
     end
 
     def create_payment
       order.payments.create(
-        source: active_card,
+        source: payment_source,
         amount: order.total,
-        payment_method: active_card.payment_method,
+        payment_method: payment_method,
       )
     end
 

--- a/app/services/solidus_subscriptions/subscription_generator.rb
+++ b/app/services/solidus_subscriptions/subscription_generator.rb
@@ -25,6 +25,8 @@ module SolidusSubscriptions
         store: order.store,
         shipping_address: order.ship_address,
         billing_address: order.bill_address,
+        payment_source: order.payments.valid.last&.payment_source,
+        payment_method: order.payments.valid.last&.payment_method,
         **configuration.to_h
       }
 

--- a/app/views/spree/admin/subscriptions/_form.html.erb
+++ b/app/views/spree/admin/subscriptions/_form.html.erb
@@ -53,6 +53,39 @@
     </div>
   </fieldset>
 
+  <% if @subscription.persisted? && @subscription.user %>
+    <div class="js-edit-subscription-payment">
+      <fieldset class="no-border-bottom">
+        <legend><%= t('spree.admin.subscriptions.edit.payment') %></legend>
+
+        <div class="field">
+          <%= f.label :payment_method %>
+          <%= f.select :payment_method_id, @payment_methods.map { |pm| [pm.name, pm.id] }, { include_blank: true }, class: 'select2 fullwidth' %>
+        </div>
+
+        <div class="field">
+          <%= f.label :payment_source %>
+          <%= f.select :payment_source_id, nil, {}, class: 'select2 fullwidth' do %>
+            <option<% if @subscription.payment_source.nil? %> selected<% end %>></option>
+            <% @subscription.user.wallet_payment_sources.select { |wps| wps.payment_source.reusable? }.each do |wps| %>
+              <option
+                value="<%= wps.payment_source_id %>"
+                data-js-payment-method-id="<%= wps.payment_source.payment_method.id %>"
+                <% if @subscription.payment_source == wps.payment_source %> selected<% end %>
+              >
+                <% if wps.payment_source.respond_to?(:display_number) %>
+                  <%= wps.payment_source.display_number %> (<%= wps.payment_source.gateway_customer_profile_id %>)
+                <% else %>
+                  <%= wps.payment_source.gateway_customer_profile_id %>
+                <% end %>
+              </option>
+            <% end %>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
+  <% end %>
+
   <div class="row">
     <div class="col-6">
       <fieldset class="no-border-bottom">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
           sidebar: Status
           details: Details
           installments: Installments
+          payment: Payment
         new:
           back: Back to Subscriptions List
           title: Create a Susbcription

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,6 @@ Spree::Core::Engine.routes.draw do
       delete :cancel, on: :member
       post :activate, on: :member
       post :skip, on: :member
-
       resources :installments, only: [:index, :show]
     end
   end

--- a/db/migrate/20200617155042_add_payment_source_to_subscriptions.rb
+++ b/db/migrate/20200617155042_add_payment_source_to_subscriptions.rb
@@ -1,0 +1,6 @@
+class AddPaymentSourceToSubscriptions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :solidus_subscriptions_subscriptions, :payment_source_type, :string
+    add_column :solidus_subscriptions_subscriptions, :payment_source_id, :integer
+  end
+end

--- a/db/migrate/20200618092951_add_payment_method_to_subscriptions.rb
+++ b/db/migrate/20200618092951_add_payment_method_to_subscriptions.rb
@@ -1,0 +1,11 @@
+class AddPaymentMethodToSubscriptions < ActiveRecord::Migration[6.0]
+  def change
+    add_reference(
+      :solidus_subscriptions_subscriptions,
+      :payment_method,
+      type: :integer,
+      index: { name: :index_subscription_payment_method_id },
+      foreign_key: { to_table: :spree_payment_methods }
+    )
+  end
+end

--- a/spec/services/solidus_subscriptions/checkout_spec.rb
+++ b/spec/services/solidus_subscriptions/checkout_spec.rb
@@ -293,8 +293,50 @@ RSpec.describe SolidusSubscriptions::Checkout do
         }
       end
 
-      it 'ships to the subscription address' do
+      it 'bills to the subscription address' do
         expect(subject.bill_address).to eq billing_address
+      end
+    end
+
+    context 'the subscription has a payment method' do
+      it_behaves_like 'a completed checkout'
+      let(:payment_method) { create :check_payment_method }
+      let(:installment_traits) do
+        {
+          subscription_traits: [{
+            payment_method: payment_method,
+            user: subscription_user,
+            line_item_traits: [{ spree_line_item: root_order.line_items.first }]
+          }]
+        }
+      end
+
+      it 'pays with the payment method' do
+        expect(subject.payments.valid.first.payment_method).to eq payment_method
+      end
+    end
+
+    context 'the subscription has a payment method and a source' do
+      it_behaves_like 'a completed checkout'
+      let(:payment_method) { create :credit_card_payment_method }
+      let(:payment_source) { create :credit_card, payment_method: payment_method, user: subscription_user }
+      let(:installment_traits) do
+        {
+          subscription_traits: [{
+            payment_method: payment_method,
+            payment_source: payment_source,
+            user: subscription_user,
+            line_item_traits: [{ spree_line_item: root_order.line_items.first }]
+          }]
+        }
+      end
+
+      it 'pays with the payment method' do
+        expect(subject.payments.valid.first.payment_method).to eq payment_method
+      end
+
+      it 'pays with the payment source' do
+        expect(subject.payments.valid.first.source).to eq payment_source
       end
     end
 

--- a/spec/services/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/services/solidus_subscriptions/subscription_generator_spec.rb
@@ -2,51 +2,49 @@ require 'spec_helper'
 
 RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
   describe '.activate' do
-    subject { described_class.activate(subscription_line_items) }
-
-    let(:subscription_line_item) { subscription_line_items.first }
-    let(:user) { subscription_line_items.first.order.user }
-    let(:store) { subscription_line_items.first.order.store }
-
-    it { is_expected.to be_a SolidusSubscriptions::Subscription }
-
-    let(:subscription_line_items) { build_list :subscription_line_item, 2 }
-
     it 'creates the correct number of subscriptions' do
-      expect { subject }.
-        to change { SolidusSubscriptions::Subscription.count }.
-        by(1)
+      subscription_line_items = build_list(:subscription_line_item, 2)
+
+      expect {
+        described_class.activate(subscription_line_items)
+      }.to change(SolidusSubscriptions::Subscription, :count).by(1)
     end
 
     it 'creates subscriptions with the correct attributes', :aggregate_failures do
-      expect(subject).to have_attributes(
-        user: user,
+      subscription_line_items = build_list(:subscription_line_item, 2)
+      subscription_line_item = subscription_line_items.first
+
+      subscription = described_class.activate(subscription_line_items)
+
+      expect(subscription.line_items).to match_array(subscription_line_items)
+      expect(subscription).to have_attributes(
+        user: subscription_line_item.order.user,
         shipping_address: subscription_line_item.spree_line_item.order.ship_address,
         billing_address: subscription_line_item.spree_line_item.order.bill_address,
         interval_length: subscription_line_item.interval_length,
         interval_units: subscription_line_item.interval_units,
         end_date: subscription_line_item.end_date,
-        store: store
+        store: subscription_line_item.order.store
       )
-
-      expect(subject.line_items).to match_array subscription_line_items
     end
   end
 
   describe '.group' do
-    subject { described_class.group(subscription_line_items) }
+    it 'groups subscriptions by interval and end date' do
+      monthly_subscriptions = build_stubbed_list(:subscription_line_item, 2)
+      bimonthly_subscriptions = build_stubbed_list(:subscription_line_item, 2, interval_length: 2)
+      weekly_subscriptions = build_stubbed_list(:subscription_line_item, 2, interval_units: :week)
+      expiring_subscriptions = build_stubbed_list(:subscription_line_item, 2, end_date: Time.zone.tomorrow)
 
-    let(:monthly_subscriptions) { build_stubbed_list :subscription_line_item, 2 }
-    let(:bimonthly_subscriptions) { build_stubbed_list :subscription_line_item, 2, interval_length: 2 }
-    let(:weekly_subscriptions) { build_stubbed_list :subscription_line_item, 2, interval_units: :week }
-    let(:expiring_subscriptions) { build_stubbed_list :subscription_line_item, 2, end_date: DateTime.current.tomorrow }
+      subscriptions = [
+        monthly_subscriptions,
+        bimonthly_subscriptions,
+        weekly_subscriptions,
+        expiring_subscriptions,
+      ]
+      grouping_result = described_class.group(subscriptions.sum)
 
-    let(:subscription_line_items) { monthly_subscriptions + bimonthly_subscriptions + weekly_subscriptions + expiring_subscriptions }
-
-    it { is_expected.to be_a Array }
-    it { is_expected.to include monthly_subscriptions }
-    it { is_expected.to include bimonthly_subscriptions }
-    it { is_expected.to include weekly_subscriptions }
-    it { is_expected.to include expiring_subscriptions }
+      expect(grouping_result).to match_array(subscriptions)
+    end
   end
 end

--- a/spec/services/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/services/solidus_subscriptions/subscription_generator_spec.rb
@@ -24,7 +24,25 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
         interval_length: subscription_line_item.interval_length,
         interval_units: subscription_line_item.interval_units,
         end_date: subscription_line_item.end_date,
-        store: subscription_line_item.order.store
+        store: subscription_line_item.order.store,
+      )
+    end
+
+    it 'copies the payment method from the order' do
+      subscription_line_item = build(:subscription_line_item)
+      payment_method = create(:credit_card_payment_method)
+      payment_source = create(:credit_card, payment_method: payment_method)
+      create(:payment,
+        order: subscription_line_item.spree_line_item.order,
+        source: payment_source,
+        payment_method: payment_method,
+      )
+
+      subscription = described_class.activate([subscription_line_item])
+
+      expect(subscription).to have_attributes(
+        payment_method: payment_method,
+        payment_source: payment_source,
       )
     end
   end


### PR DESCRIPTION
Closes #116.

Implements the ability to have different payment methods and sources on each subscription. The payment information is copied from the order that originated the subscription, when possible.

Because the payment method is also stored, this PR also opens up the possibility of charging subscriptions via non-credit-card payment methods such as checks or wire transfers. All you have to do is set the right `payment_method` on the subscription and not set the `payment_source`.