### PR TITLE
Allow admins to make master variants subcribable

### DIFF
--- a/app/decorators/models/solidus_subscriptions/spree/product/delegate_subscribable.rb
+++ b/app/decorators/models/solidus_subscriptions/spree/product/delegate_subscribable.rb
@@ -1,0 +1,15 @@
+module SolidusSubscriptions
+  module Spree
+    module Product
+      module DelegateSubscribable
+        def self.prepended(base)
+          base.class_eval do
+            delegate :subscribable, :subscribable=, to: :find_or_build_master
+          end
+        end
+      end
+    end
+  end
+end
+
+Spree::Product.prepend(SolidusSubscriptions::Spree::Product::DelegateSubscribable)

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -24,7 +24,7 @@ module SolidusSubscriptions
 
     accepts_nested_attributes_for :shipping_address
     accepts_nested_attributes_for :billing_address
-    accepts_nested_attributes_for :line_items, allow_destroy: true, reject_if: -> (p) { p[:quantity].blank? }
+    accepts_nested_attributes_for :line_items, allow_destroy: true, reject_if: ->(p) { p[:quantity].blank? }
 
     before_validation :set_payment_method
     before_update :update_actionable_date_if_interval_changed

--- a/app/overrides/views/admin_subscribable_product_checkbox.rb
+++ b/app/overrides/views/admin_subscribable_product_checkbox.rb
@@ -1,0 +1,6 @@
+Deface::Override.new(
+  virtual_path: "spree/admin/products/_form",
+  name: "solidus_subscriptions_product_subscribable_checkbox",
+  insert_after: "[data-hook='admin_product_form_promotionable']",
+  partial: "spree/admin/products/subscribable_checkbox"
+)

--- a/app/overrides/views/admin_subscribable_variant_checkbox.rb
+++ b/app/overrides/views/admin_subscribable_variant_checkbox.rb
@@ -1,6 +1,6 @@
 Deface::Override.new(
   virtual_path: "spree/admin/variants/_form",
-  name: "solidus_subscriptions_subscribable_checkbox",
+  name: "solidus_subscriptions_variant_subscribable_checkbox",
   insert_after: "[data-hook='track_inventory']",
   partial: "spree/admin/variants/subscribable_checkbox"
 )

--- a/app/views/spree/admin/products/_subscribable_checkbox.html.erb
+++ b/app/views/spree/admin/products/_subscribable_checkbox.html.erb
@@ -1,0 +1,8 @@
+<div data-hook="admin_product_form_subscribable">
+  <%= f.field_container :subscribable do %>
+    <label>
+      <%= f.check_box :subscribable %>
+      <%= Spree::Product.human_attribute_name(:subscribable) %>
+    </label>
+  <% end %>
+</div>

--- a/lib/generators/solidus_subscriptions/install/install_generator.rb
+++ b/lib/generators/solidus_subscriptions/install/install_generator.rb
@@ -6,13 +6,13 @@ module SolidusSubscriptions
       class_option :auto_run_migrations, type: :boolean, default: false
 
       def add_javascripts
-        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_subscriptions\n" # rubocop:disable Metrics/LineLength
-        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_subscriptions\n" # rubocop:disable Metrics/LineLength
+        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/solidus_subscriptions\n"
+        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_subscriptions\n"
       end
 
       def add_stylesheets
         inject_into_file 'vendor/assets/stylesheets/spree/frontend/all.css', " *= require spree/frontend/solidus_subscriptions\n", before: %r{\*/}, verbose: true # rubocop:disable Metrics/LineLength
-        inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/solidus_subscriptions\n", before: %r{\*/}, verbose: true # rubocop:disable Metrics/LineLength
+        inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/solidus_subscriptions\n", before: %r{\*/}, verbose: true
       end
 
       def add_migrations
@@ -20,7 +20,7 @@ module SolidusSubscriptions
       end
 
       def run_migrations
-        run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask('Would you like to run the migrations now? [Y/n]')) # rubocop:disable Metrics/LineLength
+        run_migrations = options[:auto_run_migrations] || ['', 'y', 'Y'].include?(ask('Would you like to run the migrations now? [Y/n]'))
         if run_migrations
           run 'bin/rails db:migrate'
         else

--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  spec.add_dependency 'solidus_support', '~> 0.5'
   spec.add_dependency 'deface'
   spec.add_dependency 'i18n'
+  spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
+  spec.add_dependency 'solidus_support', '~> 0.5'
   spec.add_dependency 'state_machines'
 
   spec.add_development_dependency 'rspec-activemodel-mocks'

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -299,14 +299,12 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
         payment_source = create(:credit_card,
           payment_method: payment_method,
           gateway_customer_profile_id: 'BGS-123',
-          user: user,
-        )
+          user: user,)
 
         subscription = create(:subscription,
           user: user,
           payment_method: payment_method,
-          payment_source: payment_source,
-        )
+          payment_source: payment_source,)
 
         expect(subscription.payment_source_to_use).to eq(payment_source)
       end
@@ -343,14 +341,12 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
         payment_source = create(:credit_card,
           payment_method: payment_method,
           gateway_customer_profile_id: 'BGS-123',
-          user: user,
-        )
+          user: user,)
 
         subscription = create(:subscription,
           user: user,
           payment_method: payment_method,
-          payment_source: payment_source,
-        )
+          payment_source: payment_source,)
 
         expect(subscription.payment_method_to_use).to eq(payment_method)
       end

--- a/spec/services/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/services/solidus_subscriptions/subscription_generator_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
       create(:payment,
         order: subscription_line_item.spree_line_item.order,
         source: payment_source,
-        payment_method: payment_method,
-      )
+        payment_method: payment_method,)
 
       subscription = described_class.activate([subscription_line_item])
 

--- a/spec/services/solidus_subscriptions/subscription_promotion_rule_spec.rb
+++ b/spec/services/solidus_subscriptions/subscription_promotion_rule_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe SolidusSubscriptions::SubscriptionPromotionRule do
       it { is_expected.to be_truthy }
     end
 
-    context 'when the order contains a line item with a subscription' do
+    context 'when the order does not contain a line item with a subscription' do
       let(:line_items) { build_list(:line_item, 1) }
       it { is_expected.to be_falsy }
     end


### PR DESCRIPTION
Closes #130.

Allows administrators to mark the master variant of a product as subscribable.