### PR TITLE
Use parent strategy when building associations in factories

### DIFF
--- a/lib/solidus_subscriptions/testing_support/factories/installment_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/installment_factory.rb
@@ -3,11 +3,11 @@ FactoryBot.define do
     transient {
       subscription_traits { [] }
     }
-    subscription { build :subscription, :with_line_item, *subscription_traits }
+    subscription { association(:subscription, :with_line_item, *subscription_traits) }
 
     trait :failed do
       actionable_date { Time.zone.yesterday }
-      details { build_list(:installment_detail, 1, installment: @instance) }
+      details { [association(:installment_detail, installment: @instance)] }
     end
 
     trait :success do
@@ -16,7 +16,7 @@ FactoryBot.define do
       end
 
       details do
-        build_list(:installment_detail, 1, :success, installment: @instance, order: order)
+        [association(:installment_detail, :success, installment: @instance, order: order)]
       end
     end
   end

--- a/lib/solidus_subscriptions/testing_support/factories/line_item_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/line_item_factory.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
         subscription_traits { [] }
       end
 
-      subscription { build :subscription, *subscription_traits }
+      subscription { association :subscription, *subscription_traits }
     end
   end
 end

--- a/lib/solidus_subscriptions/testing_support/factories/spree/line_item_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/spree/line_item_factory.rb
@@ -6,11 +6,9 @@ FactoryBot.modify do
       end
 
       subscription_line_items do
-        build_list(
-          :subscription_line_item,
-          n_subscription_line_items,
-          spree_line_item: @instance
-        )
+        Array.new(n_subscription_line_items) do
+          association :subscription_line_item, spree_line_item: @instance
+        end
       end
     end
   end

--- a/lib/solidus_subscriptions/testing_support/factories/spree/order_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/spree/order_factory.rb
@@ -6,12 +6,9 @@ FactoryBot.modify do
       end
 
       line_items do
-        build_list(
-          :line_item,
-          n_line_items,
-          :with_subscription_line_items,
-          order: @instance
-        )
+        Array.new(n_line_items) do
+          association :line_item, :with_subscription_line_items, order: @instance
+        end
       end
     end
   end

--- a/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
         line_item_traits { [] }
       end
 
-      line_items { build_list :subscription_line_item, 1, *line_item_traits }
+      line_items { [association(:subscription_line_item, *line_item_traits)] }
     end
 
     trait :with_shipping_address do


### PR DESCRIPTION
Adjusts the factories to always use `association` when building associated records. This fixes a weird bug that would occur when creating a `subscription_line_item` (and potentially others).