### PR TITLE
Improve dummy data generation

### DIFF
--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -44,25 +44,13 @@ module SolidusSubscriptions
     # Get a placeholder line item for calculating the values of future
     # subscription orders. It is frozen and cannot be saved
     def dummy_line_item
-      li = LineItemBuilder.new([self]).spree_line_items.first
-      return unless li
+      line_item = LineItemBuilder.new([self]).spree_line_items.first
+      return unless line_item
 
-      li.order = dummy_order
-      li.validate
-      li.freeze
-    end
+      line_item.order = subscription.dummy_order_without_line_items
 
-    private
-
-    # Get a placeholder order for calculating the values of future
-    # subscription orders. It is a frozen duplicate of the current order and
-    # cannot be saved
-    def dummy_order
-      order = spree_line_item ? spree_line_item.order.dup : ::Spree::Order.create
-      order.ship_address = subscription.shipping_address || subscription.user.ship_address if subscription
-      order.bill_address = subscription.billing_address || subscription.user.bill_address if subscription
-
-      order.freeze
+      line_item.validate
+      line_item.freeze
     end
   end
 end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -215,6 +215,23 @@ module SolidusSubscriptions
       billing_address || user.bill_address
     end
 
+    def dummy_order_without_line_items
+      order = ::Spree::Order.new(
+        ship_address: shipping_address_to_use,
+        bill_address: billing_address_to_use,
+      )
+
+      yield order if block_given?
+
+      order.freeze
+    end
+
+    def dummy_order
+      dummy_order_without_line_items do |order|
+        order.line_items = LineItemBuilder.new(line_items.to_a).spree_line_items
+      end
+    end
+
     private
 
     def check_successive_skips_exceeded


### PR DESCRIPTION
This PR improves the performance `SubscriptionLineItem#dummy_line_item` by using an ephemeral order rather than persisting a new one to the DB, in situations where the line item is not associated to a completed order.

It also implements a `Subscription#dummy_order` method that allows developers to calculate the value of a subscription's entire content rather than just a single line item.