### PR TITLE
Subscription events

### DIFF
--- a/app/controllers/spree/admin/subscription_events_controller.rb
+++ b/app/controllers/spree/admin/subscription_events_controller.rb
@@ -1,0 +1,35 @@
+module Spree
+  module Admin
+    class SubscriptionEventsController < ResourceController
+      belongs_to 'subscription', model_class: SolidusSubscriptions::Subscription
+
+      skip_before_action :load_resource, only: :index
+
+      def index
+        @search = collection.ransack((params[:q] || {}).reverse_merge(s: 'created_at desc'))
+
+        @subscription_events = @search.result(distinct: true).
+          page(params[:page]).
+          per(params[:per_page] || 20)
+      end
+
+      private
+
+      def model_class
+        ::SolidusSubscriptions::SubscriptionEvent
+      end
+
+      def find_resource
+        parent.events.find(params[:id])
+      end
+
+      def build_resource
+        parent.events.build
+      end
+
+      def collection
+        parent.events
+      end
+    end
+  end
+end

--- a/app/models/solidus_subscriptions/subscription_event.rb
+++ b/app/models/solidus_subscriptions/subscription_event.rb
@@ -1,0 +1,22 @@
+module SolidusSubscriptions
+  class SubscriptionEvent < ApplicationRecord
+    belongs_to :subscription, class_name: 'SolidusSubscriptions::Subscription', inverse_of: :events
+
+    after_initialize do
+      self.details ||= {}
+    end
+
+    after_create :emit_event
+
+    private
+
+    def emit_event
+      return unless defined?(::Spree::Event)
+
+      ::Spree::Event.fire(
+        "solidus_subscriptions.#{event_type}",
+        details.deep_symbolize_keys.merge(subscription: subscription),
+      )
+    end
+  end
+end

--- a/app/views/spree/admin/shared/_subscription_tabs.html.erb
+++ b/app/views/spree/admin/shared/_subscription_tabs.html.erb
@@ -7,6 +7,9 @@
       <li<%== ' class="active"' if current == :installments %>>
         <%= link_to t("spree.admin.subscriptions.edit.installments"), spree.admin_subscription_installments_path(subscription) %>
       </li>
+      <li<%== ' class="active"' if current == :events %>>
+        <%= link_to t("spree.admin.subscriptions.edit.events"), spree.admin_subscription_subscription_events_path(subscription) %>
+      </li>
     </ul>
   </nav>
 <% end %>

--- a/app/views/spree/admin/subscription_events/_state_pill.html.erb
+++ b/app/views/spree/admin/subscription_events/_state_pill.html.erb
@@ -1,0 +1,8 @@
+<% state_class = {
+    fulfilled: 'active',
+    unfulfilled: 'error',
+}[installment.state.to_sym] %>
+
+<span class="pill pill-<%= state_class %>">
+  <%= SolidusSubscriptions::Installment.human_attribute_name("state.#{installment.state}") %>
+</span>

--- a/app/views/spree/admin/subscription_events/index.html.erb
+++ b/app/views/spree/admin/subscription_events/index.html.erb
@@ -1,0 +1,42 @@
+<% content_for(:page_title, t('.title')) %>
+
+<%= render 'spree/admin/shared/subscription_breadcrumbs', subscription: @subscription %>
+<%= render 'spree/admin/shared/subscription_sidebar', subscription: @subscription %>
+<%= render 'spree/admin/shared/subscription_tabs', current: :events, subscription: @subscription %>
+<%= render 'spree/admin/shared/subscription_actions', subscription: @subscription %>
+
+<fieldset class="no-border-bottom">
+  <legend><%= t('spree.admin.subscription_events.index.title') %></legend>
+
+  <%= paginate @subscription_events, theme: 'solidus_admin' %>
+
+  <table id="listing_subscription_events" class="index">
+    <thead>
+      <tr data-hook="admin_subscription_events_index_headers">
+        <th><%= SolidusSubscriptions::SubscriptionEvent.human_attribute_name(:event_type) %></th>
+        <th><%= SolidusSubscriptions::SubscriptionEvent.human_attribute_name(:details) %></th>
+        <th><%= sort_link(@search, :created_at, SolidusSubscriptions::SubscriptionEvent.human_attribute_name(:created_at)) %></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @subscription_events.each do |event| %>
+        <tr>
+          <td><%= event.event_type %></td>
+          <td>
+            <% if event.details.is_a?(Hash) %>
+              <% event.details.each_pair do |key, value| %>
+                <strong><%= key %></strong>: <%= value %><br>
+              <% end %>
+            <% else %>
+              <%= event.details %>
+            <% end %>
+          </td>
+          <td><%= l event.created_at %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @subscription_events, theme: 'solidus_admin' %>
+</fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
           sidebar: Status
           details: Details
           installments: Installments
+          events: Events
           payment: Payment
         new:
           back: Back to Subscriptions List
@@ -52,6 +53,9 @@ en:
       installments:
         index:
           title: Installments
+      subscription_events:
+        index:
+          title: Events
     promotion_rule_types:
       subscription_promotion_rule:
         name: Subscription

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Spree::Core::Engine.routes.draw do
       post :activate, on: :member
       post :skip, on: :member
       resources :installments, only: [:index, :show]
+      resources :subscription_events, only: :index
     end
   end
 end

--- a/db/migrate/20200730101242_create_solidus_subscriptions_subscription_events.rb
+++ b/db/migrate/20200730101242_create_solidus_subscriptions_subscription_events.rb
@@ -1,0 +1,17 @@
+class CreateSolidusSubscriptionsSubscriptionEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :solidus_subscriptions_subscription_events do |t|
+      t.belongs_to(
+        :subscription,
+        null: false,
+        foreign_key: { to_table: :solidus_subscriptions_subscriptions },
+        index: { name: :idx_solidus_subscription_events_on_subscription_id },
+        type: :integer,
+      )
+      t.string :event_type, null: false
+      t.json :details, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/solidus_subscriptions/testing_support/factories/subscription_event_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/subscription_event_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :subscription_event, class: 'SolidusSubscriptions::SubscriptionEvent' do
+    subscription
+    event_type { 'test_event' }
+  end
+end

--- a/spec/models/solidus_subscriptions/subscription_event_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_event_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe SolidusSubscriptions::SubscriptionEvent do
+  describe '#save' do
+    it 'emits a Solidus event' do
+      event_klass = class_spy('Spree::Event')
+      stub_const('Spree::Event', event_klass)
+
+      subscription = create(:subscription)
+      subscription_event = create(:subscription_event, subscription: subscription, event_type: 'test_event', details: { foo: 'bar' })
+
+      expect(event_klass).to have_received(:fire).with('solidus_subscriptions.test_event', subscription: subscription_event.subscription, foo: 'bar')
+    end
+  end
+end


### PR DESCRIPTION
Implements a simple `SubscriptionEvent` model to keep track of different events in a subscription's lifecycle (cancellations, reactivations etc.) These events can then be seen on the subscription page in the backend.

The events are also emitted via `Spree::Event` when it's available.