### PR TITLE
Add order association to subscriptions

### DIFF
--- a/app/decorators/models/solidus_subscriptions/spree/order/subscription_association.rb
+++ b/app/decorators/models/solidus_subscriptions/spree/order/subscription_association.rb
@@ -1,0 +1,13 @@
+module SolidusSubscriptions
+  module Spree
+    module Order
+      module SubscriptionAssociation
+        def self.prepended(base)
+          base.belongs_to :subscription, class_name: '::SolidusSubscriptions::Subscription', optional: true
+        end
+      end
+    end
+  end
+end
+
+Spree::Order.prepend(SolidusSubscriptions::Spree::Order::SubscriptionAssociation)

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -11,6 +11,7 @@ module SolidusSubscriptions
     has_many :line_items, class_name: 'SolidusSubscriptions::LineItem', inverse_of: :subscription
     has_many :installments, class_name: 'SolidusSubscriptions::Installment'
     has_many :events, class_name: 'SolidusSubscriptions::SubscriptionEvent'
+    has_many :orders, class_name: '::Spree::Order', inverse_of: :subscription
     belongs_to :store, class_name: '::Spree::Store'
     belongs_to :shipping_address, class_name: '::Spree::Address', optional: true
     belongs_to :billing_address, class_name: '::Spree::Address', optional: true

--- a/app/services/solidus_subscriptions/checkout.rb
+++ b/app/services/solidus_subscriptions/checkout.rb
@@ -58,7 +58,8 @@ module SolidusSubscriptions
         user: user,
         email: user.email,
         store: subscription.store || ::Spree::Store.default,
-        subscription_order: true
+        subscription_order: true,
+        subscription: subscription
       )
     end
 

--- a/db/migrate/20200917072152_add_subscription_reference_to_orders.rb
+++ b/db/migrate/20200917072152_add_subscription_reference_to_orders.rb
@@ -1,0 +1,5 @@
+class AddSubscriptionReferenceToOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :spree_orders, :subscription, null: true, foreign_key: { to_table: :solidus_subscriptions_subscriptions }
+  end
+end


### PR DESCRIPTION
This PR adds a bi-directional `order` association towards `SolidusSubscriptions::Subscription`. This helps in cases we'd need to access easily orders related to a subscription and vice-versa.