### PR TITLE
Implement a `LineItem#subscribable` association

### DIFF
--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -33,6 +33,7 @@ module SolidusSubscriptions
       inverse_of: :line_items,
       optional: true
     )
+    belongs_to :subscribable, class_name: "::#{SolidusSubscriptions.configuration.subscribable_class}"
 
     validates :subscribable_id, presence: true
     validates :quantity, numericality: { greater_than: 0 }

--- a/lib/generators/solidus_subscriptions/install/templates/initializer.rb
+++ b/lib/generators/solidus_subscriptions/install/templates/initializer.rb
@@ -5,6 +5,9 @@ SolidusSubscriptions.configure do |config|
   # you subclass from the the dispatcher you are replacing, and call
   # `super` from within the #dispatch method (if you override it).
 
+  # The ActiveRecord model users can subscribe to.
+  # config.subscribable_class = 'Spree::Variant'
+
   # This handler is called when a subscription order is successfully placed.
   # config.success_dispatcher_class = 'SolidusSubscriptions::SuccessDispatcher'
 

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -8,7 +8,7 @@ module SolidusSubscriptions
       :success_dispatcher_class, :failure_dispatcher_class, :payment_failed_dispatcher_class,
       :out_of_stock_dispatcher, :maximum_successive_skips, :reprocessing_interval,
       :minimum_cancellation_notice, :processing_queue, :subscription_line_item_attributes,
-      :subscription_attributes,
+      :subscription_attributes, :subscribable_class,
     )
 
     def success_dispatcher_class
@@ -67,6 +67,11 @@ module SolidusSubscriptions
           billing_address_attributes: Spree::PermittedAttributes.address_attributes
         },
       ]
+    end
+
+    def subscribable_class
+      @subscribable_class ||= 'Spree::Variant'
+      @subscribable_class.constantize
     end
   end
 end


### PR DESCRIPTION
This paves the way for integrating with [solidus_tracking](https://github.com/solidusio-contrib/solidus_tracking), which needs access to the subscribable object in order to serialize it.