### PR TITLE
Improve dispatchers API

### DIFF
--- a/app/services/solidus_subscriptions/dispatcher.rb
+++ b/app/services/solidus_subscriptions/dispatcher.rb
@@ -4,31 +4,20 @@ module SolidusSubscriptions
   class Dispatcher
     attr_reader :installments, :order
 
-    # Get a new instance of the FailureDispatcher
+    # Returns a new instance of this dispatcher.
     #
-    # @param installments [Array<SolidusSubscriptions::Installment>] The
-    #   installments which have failed to be fulfilled
+    # @param installments [Array<SolidusSubscriptions::Installment>] The installments to process
+    #   with this dispatcher
+    # @param order [Spree::Order] The order that was generated as a result of these installments
     #
-    # @return [SolidusSubscriptions::FailureDispatcher]
+    # @return [SolidusSubscriptions::Dispatcher]
     def initialize(installments, order = nil)
       @installments = installments
       @order = order
     end
 
     def dispatch
-      notify
-    end
-
-    private
-
-    def notify
-      Rails.logger.tagged('Event') do
-        Rails.logger.info message.squish.tr("\n", ' ')
-      end
-    end
-
-    def message
-      raise 'A message should be set in subclasses of Dispatcher'
+      raise NotImplementedError
     end
   end
 end

--- a/app/services/solidus_subscriptions/failure_dispatcher.rb
+++ b/app/services/solidus_subscriptions/failure_dispatcher.rb
@@ -1,21 +1,14 @@
 # frozen_string_literal: true
 
-# A handler for behaviour that should happen after installments are marked as
-# failures
+# Handles failed installments.
 module SolidusSubscriptions
   class FailureDispatcher < Dispatcher
     def dispatch
-      order.touch :completed_at
+      order.touch(:completed_at)
       order.cancel
-      installments.each { |i| i.failed!(order) }
-      super
-    end
-
-    def message
-      "
-      Something went wrong processing installments: #{installments.map(&:id).join(', ')}.
-      They have been marked for reprocessing.
-      "
+      installments.each do |installment|
+        installment.failed!(order)
+      end
     end
   end
 end

--- a/app/services/solidus_subscriptions/out_of_stock_dispatcher.rb
+++ b/app/services/solidus_subscriptions/out_of_stock_dispatcher.rb
@@ -1,21 +1,10 @@
 # frozen_string_literal: true
 
-# This service class is intended to provide callback behaviour to handle
-# the case where an installment cannot be processed due to lack of stock.
+# Handles installments that cannot be processed for lack of stock.
 module SolidusSubscriptions
   class OutOfStockDispatcher < Dispatcher
     def dispatch
       installments.each(&:out_of_stock)
-      super
-    end
-
-    private
-
-    def message
-      "
-      The following installments cannot be fulfilled due to lack of stock:
-      #{installments.map(&:id).join(', ')}.
-      "
     end
   end
 end

--- a/app/services/solidus_subscriptions/payment_failed_dispatcher.rb
+++ b/app/services/solidus_subscriptions/payment_failed_dispatcher.rb
@@ -1,24 +1,14 @@
 # frozen_string_literal: true
 
-# This service class is intended to provide callback behaviour to handle
-# the case where a subscription order cannot be processed because a payment
-# failed
+# Handles payment failures for subscription installments.
 module SolidusSubscriptions
   class PaymentFailedDispatcher < Dispatcher
     def dispatch
-      order.touch :completed_at
+      order.touch(:completed_at)
       order.cancel
-      installments.each { |i| i.payment_failed!(order) }
-      super
-    end
-
-    private
-
-    def message
-      "
-      The following installments could not be processed due to payment
-      authorization failure: #{installments.map(&:id).join(', ')}
-      "
+      installments.each do |installment|
+        installment.payment_failed!(order)
+      end
     end
   end
 end

--- a/app/services/solidus_subscriptions/success_dispatcher.rb
+++ b/app/services/solidus_subscriptions/success_dispatcher.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
-# This service class is intended to provide callback behaviour to handle
-# an installment successfully being processed
+# Handles installments that are processed successfully.
 module SolidusSubscriptions
   class SuccessDispatcher < Dispatcher
     def dispatch
-      installments.each { |i| i.success!(order) }
-      super
-    end
-
-    private
-
-    def message
-      "Successfully processed installments: #{installments.map(&:id).join(', ')}"
+      installments.each do |installment|
+        installment.success!(order)
+      end
     end
   end
 end

--- a/spec/services/solidus_subscriptions/dispatcher_spec.rb
+++ b/spec/services/solidus_subscriptions/dispatcher_spec.rb
@@ -1,14 +1,11 @@
-require 'spec_helper'
-
 RSpec.describe SolidusSubscriptions::Dispatcher do
   describe '#dispatch' do
-    subject { described_class.new([]).dispatch }
+    it 'raises a NotImplementedError' do
+      dispatcher = described_class.new([])
 
-    it 'must be subclassed' do
-      expect { subject }.to raise_error(
-        RuntimeError,
-        'A message should be set in subclasses of Dispatcher'
-      )
+      expect {
+        dispatcher.dispatch
+      }.to raise_error(NotImplementedError)
     end
   end
 end

--- a/spec/services/solidus_subscriptions/out_of_stock_dispatcher_spec.rb
+++ b/spec/services/solidus_subscriptions/out_of_stock_dispatcher_spec.rb
@@ -1,26 +1,12 @@
-require 'spec_helper'
-
 RSpec.describe SolidusSubscriptions::OutOfStockDispatcher do
-  let(:dispatcher) { described_class.new(installments) }
-  let(:installments) { build_list(:installment, 2) }
-
-  describe 'initialization' do
-    subject { dispatcher }
-
-    it { is_expected.to be_a described_class }
-  end
-
   describe '#dispatch' do
-    subject { dispatcher.dispatch }
+    it 'marks all the installments as out of stock' do
+      installments = Array.new(2) { instance_spy(SolidusSubscriptions::Installment) }
 
-    it 'marks all the installments out of stock' do
-      expect(installments).to all receive(:out_of_stock).once
-      subject
-    end
+      dispatcher = described_class.new(installments)
+      dispatcher.dispatch
 
-    it 'logs the failure' do
-      expect(dispatcher).to receive(:notify).once
-      subject
+      expect(installments).to all(have_received(:out_of_stock).once)
     end
   end
 end

--- a/spec/services/solidus_subscriptions/payment_failed_dispatcher_spec.rb
+++ b/spec/services/solidus_subscriptions/payment_failed_dispatcher_spec.rb
@@ -1,34 +1,27 @@
-require 'spec_helper'
-
 RSpec.describe SolidusSubscriptions::PaymentFailedDispatcher do
-  let(:dispatcher) { described_class.new(installments, order) }
-  let(:installments) { build_list(:installment, 2) }
-  let(:order) { create :order_with_line_items }
-
-  describe 'initialization' do
-    subject { dispatcher }
-
-    it { is_expected.to be_a described_class }
-  end
-
   describe '#dispatch' do
-    subject { dispatcher.dispatch }
+    it 'marks all the installments as payment_failed' do
+      installments = Array.new(2) { instance_spy(SolidusSubscriptions::Installment) }
+      order = create(:order_with_line_items)
 
-    it 'marks all the installments out of stock' do
-      expect(installments).to all receive(:payment_failed!).once
-      subject
-    end
+      dispatcher = described_class.new(installments, order)
+      dispatcher.dispatch
 
-    it 'logs the failure' do
-      expect(dispatcher).to receive(:notify).once
-      subject
+      expect(installments).to all(have_received(:payment_failed!).with(order).once)
     end
 
     it 'cancels the order' do
       if Spree.solidus_gem_version > Gem::Version.new('2.10')
-        skip 'Orders in cart state cannot be canceled starting from Solidus 2.11'
+        skip 'Orders in `cart` state cannot be canceled starting from Solidus 2.11.'
       end
-      expect { subject }.to change(order, :state).to 'canceled'
+
+      installments = Array.new(2) { instance_spy(SolidusSubscriptions::Installment) }
+      order = create(:order_with_line_items)
+
+      dispatcher = described_class.new(installments, order)
+      dispatcher.dispatch
+
+      expect(order.state).to eq('canceled')
     end
   end
 end

--- a/spec/services/solidus_subscriptions/success_dispatcher_spec.rb
+++ b/spec/services/solidus_subscriptions/success_dispatcher_spec.rb
@@ -1,26 +1,13 @@
-require 'spec_helper'
-
 RSpec.describe SolidusSubscriptions::SuccessDispatcher do
-  let(:dispatcher) { described_class.new(installments) }
-  let(:installments) { create_list(:installment, 1) }
-
-  describe 'initialization' do
-    subject { dispatcher }
-
-    it { is_expected.to be_a described_class }
-  end
-
   describe '#dispatch' do
-    subject { dispatcher.dispatch }
+    it 'marks all the installments as success' do
+      installments = Array.new(2) { instance_spy(SolidusSubscriptions::Installment) }
+      order = create(:order_with_line_items)
 
-    it 'marks all the installments out of stock' do
-      expect(installments).to all receive(:success!).once
-      subject
-    end
+      dispatcher = described_class.new(installments, order)
+      dispatcher.dispatch
 
-    it 'logs the failure' do
-      expect(dispatcher).to receive(:notify).once
-      subject
+      expect(installments).to all(have_received(:success!).with(order).once)
     end
   end
 end


### PR DESCRIPTION
Streamlines the dispatchers API by fixing some typos in the API documentation.

This PR also removes the built-in logging functionality, which can be easily added back in by the user if needed. Logging at the INFO level out of the box can easily pollute the logs of high-volume eCommerce applications.