### PR TITLE
Remove subscription_repopulated event

### DIFF
--- a/app/models/solidus_subscriptions/line_item.rb
+++ b/app/models/solidus_subscriptions/line_item.rb
@@ -39,10 +39,6 @@ module SolidusSubscriptions
     validates :quantity, numericality: { greater_than: 0 }
     validates :interval_length, numericality: { greater_than: 0 }, unless: -> { subscription }
 
-    after_create :emit_event_for_repopulation
-    after_update :emit_event_for_repopulation
-    after_destroy :emit_event_for_repopulation
-
     def as_json(**options)
       options[:methods] ||= [:dummy_line_item]
       super(options)
@@ -70,12 +66,6 @@ module SolidusSubscriptions
       order.bill_address = subscription.billing_address || subscription.user.bill_address if subscription
 
       order.freeze
-    end
-
-    def emit_event_for_repopulation
-      return unless subscription
-
-      ::Spree::Event.fire('solidus_subscriptions.subscription_repopulated', subscription: subscription)
     end
   end
 end

--- a/app/subscribers/solidus_subscriptions/event_storage_subscriber.rb
+++ b/app/subscribers/solidus_subscriptions/event_storage_subscriber.rb
@@ -8,7 +8,6 @@ module SolidusSubscriptions
     event_action :track_subscription_activated, event_name: 'solidus_subscriptions.subscription_activated'
     event_action :track_subscription_canceled, event_name: 'solidus_subscriptions.subscription_canceled'
     event_action :track_subscription_ended, event_name: 'solidus_subscriptions.subscription_ended'
-    event_action :track_subscription_repopulated, event_name: 'solidus_subscriptions.subscription_repopulated'
     event_action :track_subscription_shipping_address_changed, event_name: 'solidus_subscriptions.subscription_shipping_address_changed'
     event_action :track_subscription_billing_address_changed, event_name: 'solidus_subscriptions.subscription_billing_address_changed'
     event_action :track_subscription_frequency_changed, event_name: 'solidus_subscriptions.subscription_frequency_changed'
@@ -37,13 +36,6 @@ module SolidusSubscriptions
     def track_subscription_ended(event)
       event.payload.fetch(:subscription).events.create!(
         event_type: 'subscription_ended',
-        details: event.payload.fetch(:subscription).as_json,
-      )
-    end
-
-    def track_subscription_repopulated(event)
-      event.payload.fetch(:subscription).events.create!(
-        event_type: 'subscription_repopulated',
         details: event.payload.fetch(:subscription).as_json,
       )
     end

--- a/spec/models/solidus_subscriptions/line_item_spec.rb
+++ b/spec/models/solidus_subscriptions/line_item_spec.rb
@@ -6,48 +6,6 @@ RSpec.describe SolidusSubscriptions::LineItem, type: :model do
   it { is_expected.to validate_numericality_of(:quantity).is_greater_than(0) }
   it { is_expected.to validate_numericality_of(:interval_length).is_greater_than(0) }
 
-  describe '#save!' do
-    context 'when the line item is new' do
-      it 'tracks a subscription_repopulated event' do
-        line_item = build(:subscription_line_item, :with_subscription)
-
-        line_item.save!
-
-        expect(line_item.subscription.events.last).to have_attributes(
-          event_type: 'subscription_repopulated',
-          details: a_hash_including('id' => line_item.subscription.id),
-        )
-      end
-    end
-
-    context 'when the line item is persisted' do
-      it 'tracks a subscription_repopulated event' do
-        line_item = create(:subscription_line_item, :with_subscription)
-
-        line_item.quantity = 2
-        line_item.save!
-
-        expect(line_item.subscription.events.last).to have_attributes(
-          event_type: 'subscription_repopulated',
-          details: a_hash_including('id' => line_item.subscription.id),
-        )
-      end
-    end
-  end
-
-  describe '#destroy!' do
-    it 'tracks a subscription_repopulated event' do
-      line_item = create(:subscription_line_item, :with_subscription)
-
-      line_item.destroy!
-
-      expect(line_item.subscription.events.last).to have_attributes(
-        event_type: 'subscription_repopulated',
-        details: a_hash_including('id' => line_item.subscription.id),
-      )
-    end
-  end
-
   describe "#interval" do
     subject { line_item.interval }
 


### PR DESCRIPTION
This event is not really useful in its current form. Instead, each store should track repopulation in a way that makes sense for them.