### PR TITLE
Add scope to permission set

### DIFF
--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -6,7 +6,7 @@ module Spree
       skip_before_action :load_resource, only: :index
 
       def index
-        @search = SolidusSubscriptions::Subscription.ransack(params[:q])
+        @search = SolidusSubscriptions::Subscription.accessible_by(current_ability).ransack(params[:q])
         @subscriptions = @search.result(distinct: true).
                          includes(:line_items, :user).
                          page(params[:page]).

--- a/bin/rails-sandbox
+++ b/bin/rails-sandbox
@@ -5,7 +5,7 @@ app_root = 'sandbox'
 unless File.exist? "#{app_root}/bin/rails"
   warn 'Creating the sandbox app...'
   Dir.chdir "#{__dir__}/.." do
-    system "#{__dir__}/sandbox" or begin
+    system "#{__dir__}/sandbox" or begin # rubocop:disable Style/RedundantBegin
       warn 'Automatic creation of the sandbox app failed'
       exit 1
     end

--- a/config/initializers/permission_sets.rb
+++ b/config/initializers/permission_sets.rb
@@ -2,6 +2,10 @@
 
 Spree.config do |config|
   config.roles.assign_permissions :default, %w[
+    SolidusSubscriptions::PermissionSets::DefaultCustomer
+  ]
+
+  config.roles.assign_permissions :admin, %w[
     SolidusSubscriptions::PermissionSets::SubscriptionManagement
   ]
 end

--- a/lib/solidus_subscriptions.rb
+++ b/lib/solidus_subscriptions.rb
@@ -7,6 +7,7 @@ require 'deface'
 require 'state_machines'
 
 require 'solidus_subscriptions/configuration'
+require 'solidus_subscriptions/permission_sets/default_customer'
 require 'solidus_subscriptions/permission_sets/subscription_management'
 require 'solidus_subscriptions/version'
 require 'solidus_subscriptions/engine'

--- a/lib/solidus_subscriptions/permission_sets/default_customer.rb
+++ b/lib/solidus_subscriptions/permission_sets/default_customer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusSubscriptions
+  module PermissionSets
+    class DefaultCustomer < ::Spree::PermissionSets::Base
+      def activate!
+        can :manage, Subscription, Subscription.where(user: user) do |subscription, guest_token|
+          (subscription.guest_token.present? && subscription.guest_token == guest_token) ||
+            (subscription.user && subscription.user == user)
+        end
+
+        can :manage, LineItem do |line_item, guest_token|
+          (line_item.subscription&.guest_token.present? && line_item.subscription.guest_token == guest_token) ||
+            (line_item.subscription&.user && line_item.subscription.user == user)
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_subscriptions/permission_sets/default_customer.rb
+++ b/lib/solidus_subscriptions/permission_sets/default_customer.rb
@@ -4,7 +4,7 @@ module SolidusSubscriptions
   module PermissionSets
     class DefaultCustomer < ::Spree::PermissionSets::Base
       def activate!
-        can :manage, Subscription, Subscription.where(user: user) do |subscription, guest_token|
+        can :manage, Subscription, ['user_id = ?', user.id] do |subscription, guest_token|
           (subscription.guest_token.present? && subscription.guest_token == guest_token) ||
             (subscription.user && subscription.user == user)
         end

--- a/lib/solidus_subscriptions/permission_sets/subscription_management.rb
+++ b/lib/solidus_subscriptions/permission_sets/subscription_management.rb
@@ -4,7 +4,7 @@ module SolidusSubscriptions
   module PermissionSets
     class SubscriptionManagement < ::Spree::PermissionSets::Base
       def activate!
-        can :manage, Subscription do |subscription, guest_token|
+        can :manage, Subscription, Subscription.where(user: user) do |subscription, guest_token|
           (subscription.guest_token.present? && subscription.guest_token == guest_token) ||
             (subscription.user && subscription.user == user)
         end

--- a/lib/solidus_subscriptions/permission_sets/subscription_management.rb
+++ b/lib/solidus_subscriptions/permission_sets/subscription_management.rb
@@ -4,15 +4,8 @@ module SolidusSubscriptions
   module PermissionSets
     class SubscriptionManagement < ::Spree::PermissionSets::Base
       def activate!
-        can :manage, Subscription, Subscription.where(user: user) do |subscription, guest_token|
-          (subscription.guest_token.present? && subscription.guest_token == guest_token) ||
-            (subscription.user && subscription.user == user)
-        end
-
-        can :manage, LineItem do |line_item, guest_token|
-          (line_item.subscription&.guest_token.present? && line_item.subscription.guest_token == guest_token) ||
-            (line_item.subscription&.user && line_item.subscription.user == user)
-        end
+        can :manage, Subscription
+        can :manage, LineItem
       end
     end
   end

--- a/spec/lib/solidus_subscriptions/permission_sets/default_customer_spec.rb
+++ b/spec/lib/solidus_subscriptions/permission_sets/default_customer_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
+  context 'when the user is authenticated' do
+    it 'is allowed to manage their subscriptions' do
+      user = create(:user)
+      subscription = create(:subscription, user: user)
+
+      ability = Spree::Ability.new(user)
+      permission_set = described_class.new(ability)
+      permission_set.activate!
+
+      expect(ability).to be_able_to(:manage, subscription)
+    end
+
+    it "is allowed to manage someone else's subscriptions" do
+      user = create(:user)
+      subscription = create(:subscription)
+
+      ability = Spree::Ability.new(user)
+      permission_set = described_class.new(ability)
+      permission_set.activate!
+
+      expect(ability).not_to be_able_to(:manage, subscription)
+    end
+
+    it 'is allowed to manage line items on their subscriptions' do
+      user = create(:user)
+      subscription = create(:subscription, user: user)
+      line_item = create(:subscription_line_item, subscription: subscription)
+
+      ability = Spree::Ability.new(user)
+      permission_set = described_class.new(ability)
+      permission_set.activate!
+
+      expect(ability).to be_able_to(:manage, line_item)
+    end
+
+    it "is not allowed to manage line items on someone else's subscriptions" do
+      user = create(:user)
+      subscription = create(:subscription)
+      line_item = create(:subscription_line_item, subscription: subscription)
+
+      ability = Spree::Ability.new(user)
+      permission_set = described_class.new(ability)
+      permission_set.activate!
+
+      expect(ability).not_to be_able_to(:manage, line_item)
+    end
+  end
+
+  context 'when the user provides a guest token' do
+    it 'is allowed to manage their subscriptions' do
+      subscription = create(:subscription)
+
+      ability = Spree::Ability.new(nil)
+      permission_set = described_class.new(ability)
+      permission_set.activate!
+
+      expect(ability).to be_able_to(:manage, subscription, subscription.guest_token)
+    end
+
+    it "is allowed to manage someone else's subscriptions" do
+      subscription = create(:subscription)
+
+      ability = Spree::Ability.new(nil)
+      permission_set = described_class.new(ability)
+      permission_set.activate!
+
+      expect(ability).not_to be_able_to(:manage, subscription, 'invalid')
+    end
+
+    it 'is allowed to manage line items on their subscriptions' do
+      subscription = create(:subscription)
+      line_item = create(:subscription_line_item, subscription: subscription)
+
+      ability = Spree::Ability.new(nil)
+      permission_set = described_class.new(ability)
+      permission_set.activate!
+
+      expect(ability).to be_able_to(:manage, line_item, subscription.guest_token)
+    end
+
+    it "is not allowed to manage line items on someone else's subscriptions" do
+      subscription = create(:subscription)
+      line_item = create(:subscription_line_item, subscription: subscription)
+
+      ability = Spree::Ability.new(nil)
+      permission_set = described_class.new(ability)
+      permission_set.activate!
+
+      expect(ability).not_to be_able_to(:manage, line_item, 'invalid')
+    end
+  end
+end

--- a/spec/lib/solidus_subscriptions/permission_sets/subscription_management_spec.rb
+++ b/spec/lib/solidus_subscriptions/permission_sets/subscription_management_spec.rb
@@ -1,95 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.describe SolidusSubscriptions::PermissionSets::SubscriptionManagement do
-  context 'when the user is authenticated' do
-    it 'is allowed to manage their subscriptions' do
-      user = create(:user)
-      subscription = create(:subscription, user: user)
+  it 'is allowed to manage all subscriptions' do
+    user = create(:user)
+    subscription = create(:subscription)
 
-      ability = Spree::Ability.new(user)
-      permission_set = described_class.new(ability)
-      permission_set.activate!
+    ability = Spree::Ability.new(user)
+    permission_set = described_class.new(ability)
+    permission_set.activate!
 
-      expect(ability).to be_able_to(:manage, subscription)
-    end
-
-    it "is allowed to manage someone else's subscriptions" do
-      user = create(:user)
-      subscription = create(:subscription)
-
-      ability = Spree::Ability.new(user)
-      permission_set = described_class.new(ability)
-      permission_set.activate!
-
-      expect(ability).not_to be_able_to(:manage, subscription)
-    end
-
-    it 'is allowed to manage line items on their subscriptions' do
-      user = create(:user)
-      subscription = create(:subscription, user: user)
-      line_item = create(:subscription_line_item, subscription: subscription)
-
-      ability = Spree::Ability.new(user)
-      permission_set = described_class.new(ability)
-      permission_set.activate!
-
-      expect(ability).to be_able_to(:manage, line_item)
-    end
-
-    it "is not allowed to manage line items on someone else's subscriptions" do
-      user = create(:user)
-      subscription = create(:subscription)
-      line_item = create(:subscription_line_item, subscription: subscription)
-
-      ability = Spree::Ability.new(user)
-      permission_set = described_class.new(ability)
-      permission_set.activate!
-
-      expect(ability).not_to be_able_to(:manage, line_item)
-    end
+    expect(ability).to be_able_to(:manage, subscription)
   end
 
-  context 'when the user provides a guest token' do
-    it 'is allowed to manage their subscriptions' do
-      subscription = create(:subscription)
+  it "is allowed to manage all line items" do
+    user = create(:user)
+    subscription = create(:subscription)
+    line_item = create(:subscription_line_item, subscription: subscription)
 
-      ability = Spree::Ability.new(nil)
-      permission_set = described_class.new(ability)
-      permission_set.activate!
+    ability = Spree::Ability.new(user)
+    permission_set = described_class.new(ability)
+    permission_set.activate!
 
-      expect(ability).to be_able_to(:manage, subscription, subscription.guest_token)
-    end
-
-    it "is allowed to manage someone else's subscriptions" do
-      subscription = create(:subscription)
-
-      ability = Spree::Ability.new(nil)
-      permission_set = described_class.new(ability)
-      permission_set.activate!
-
-      expect(ability).not_to be_able_to(:manage, subscription, 'invalid')
-    end
-
-    it 'is allowed to manage line items on their subscriptions' do
-      subscription = create(:subscription)
-      line_item = create(:subscription_line_item, subscription: subscription)
-
-      ability = Spree::Ability.new(nil)
-      permission_set = described_class.new(ability)
-      permission_set.activate!
-
-      expect(ability).to be_able_to(:manage, line_item, subscription.guest_token)
-    end
-
-    it "is not allowed to manage line items on someone else's subscriptions" do
-      subscription = create(:subscription)
-      line_item = create(:subscription_line_item, subscription: subscription)
-
-      ability = Spree::Ability.new(nil)
-      permission_set = described_class.new(ability)
-      permission_set.activate!
-
-      expect(ability).not_to be_able_to(:manage, line_item, 'invalid')
-    end
+    expect(ability).to be_able_to(:manage, line_item)
   end
 end


### PR DESCRIPTION
Adds an ActiveRecord scope to our default permission set, so that `#accessible_by` can be used with `SolidusSubscriptions::Subscription` once more.