### PR TITLE
Add maximum_reprocessing_attempts preference

### DIFF
--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -107,6 +107,12 @@ module SolidusSubscriptions
         transition active: :pending_cancellation
       end
 
+      event :force_cancel do
+        transition [:active, :pending_cancellation] => :canceled
+        transition inactive: :inactive
+        transition canceled: :canceled
+      end
+
       after_transition to: :canceled, do: :advance_actionable_date
 
       event :deactivate do

--- a/lib/generators/solidus_subscriptions/install/templates/initializer.rb
+++ b/lib/generators/solidus_subscriptions/install/templates/initializer.rb
@@ -22,6 +22,10 @@ SolidusSubscriptions.configure do |config|
   # Time between an installment failing to be processed and the system retrying to fulfill it.
   # config.reprocessing_interval = 1.day
 
+  # Maximum number of times the system attempts to reprocess a failed payment before cancelling
+  # the subscription (`nil` is the default and will make the system reprocess indefinitely).
+  # config.maximum_reprocessing_attempts = nil
+
   # ========================================= Dispatchers ==========================================
   #
   # These dispatchers are pluggable. If you override any handlers, it is highly encouraged that you

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -3,7 +3,8 @@
 module SolidusSubscriptions
   class Configuration
     attr_accessor(
-      :maximum_total_skips, :churn_buster_account_id, :churn_buster_api_key,
+      :maximum_total_skips, :maximum_reprocessing_attempts, :churn_buster_account_id,
+      :churn_buster_api_key,
     )
 
     attr_writer(


### PR DESCRIPTION
Adds a preference that allows the user to specify the maximum number of times the system should attempt to reprocess a subscription that failed payment before cancelling it.