### PR TITLE
Fix DefaultCustomer permission set giving guests access to admin

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
@@ -34,7 +34,7 @@ module SolidusSubscriptions
 
         def load_line_item
           @line_item = SolidusSubscriptions::LineItem.find(params[:id])
-          authorize! action_name, @line_item, subscription_guest_token
+          authorize! action_name.to_sym, @line_item, subscription_guest_token
         end
 
         def line_item_params

--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -40,7 +40,7 @@ module SolidusSubscriptions
 
         def load_subscription
           @subscription = SolidusSubscriptions::Subscription.find(params[:id])
-          authorize! action_name, @subscription, subscription_guest_token
+          authorize! action_name.to_sym, @subscription, subscription_guest_token
         end
 
         def subscription_params

--- a/bin/rails-sandbox
+++ b/bin/rails-sandbox
@@ -5,7 +5,7 @@ app_root = 'sandbox'
 unless File.exist? "#{app_root}/bin/rails"
   warn 'Creating the sandbox app...'
   Dir.chdir "#{__dir__}/.." do
-    system "#{__dir__}/sandbox" or begin # rubocop:disable Style/RedundantBegin
+    system "#{__dir__}/sandbox" or begin
       warn 'Automatic creation of the sandbox app failed'
       exit 1
     end

--- a/lib/solidus_subscriptions/permission_sets/default_customer.rb
+++ b/lib/solidus_subscriptions/permission_sets/default_customer.rb
@@ -4,12 +4,12 @@ module SolidusSubscriptions
   module PermissionSets
     class DefaultCustomer < ::Spree::PermissionSets::Base
       def activate!
-        can :manage, Subscription, ['user_id = ?', user.id] do |subscription, guest_token|
+        can [:display, :update, :skip, :cancel], Subscription, ['user_id = ?', user.id] do |subscription, guest_token|
           (subscription.guest_token.present? && subscription.guest_token == guest_token) ||
             (subscription.user && subscription.user == user)
         end
 
-        can :manage, LineItem do |line_item, guest_token|
+        can [:display, :update, :destroy], LineItem do |line_item, guest_token|
           (line_item.subscription&.guest_token.present? && line_item.subscription.guest_token == guest_token) ||
             (line_item.subscription&.user && line_item.subscription.user == user)
         end

--- a/spec/lib/solidus_subscriptions/permission_sets/default_customer_spec.rb
+++ b/spec/lib/solidus_subscriptions/permission_sets/default_customer_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
   context 'when the user is authenticated' do
-    it 'is allowed to manage their subscriptions' do
+    it 'is allowed to display and update their subscriptions' do
       user = create(:user)
       subscription = create(:subscription, user: user)
 
@@ -10,10 +10,10 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).to be_able_to(:manage, subscription)
+      expect(ability).to be_able_to([:display, :update], subscription)
     end
 
-    it "is allowed to manage someone else's subscriptions" do
+    it "is not allowed to display or update someone else's subscriptions" do
       user = create(:user)
       subscription = create(:subscription)
 
@@ -21,10 +21,10 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).not_to be_able_to(:manage, subscription)
+      expect(ability).not_to be_able_to([:display, :update], subscription)
     end
 
-    it 'is allowed to manage line items on their subscriptions' do
+    it 'is allowed to display and update line items on their subscriptions' do
       user = create(:user)
       subscription = create(:subscription, user: user)
       line_item = create(:subscription_line_item, subscription: subscription)
@@ -33,10 +33,10 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).to be_able_to(:manage, line_item)
+      expect(ability).to be_able_to([:display, :update], line_item)
     end
 
-    it "is not allowed to manage line items on someone else's subscriptions" do
+    it "is not allowed to display or update line items on someone else's subscriptions" do
       user = create(:user)
       subscription = create(:subscription)
       line_item = create(:subscription_line_item, subscription: subscription)
@@ -45,32 +45,32 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).not_to be_able_to(:manage, line_item)
+      expect(ability).not_to be_able_to([:display, :update], line_item)
     end
   end
 
   context 'when the user provides a guest token' do
-    it 'is allowed to manage their subscriptions' do
+    it 'is allowed to display and update their subscriptions' do
       subscription = create(:subscription)
 
       ability = Spree::Ability.new(nil)
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).to be_able_to(:manage, subscription, subscription.guest_token)
+      expect(ability).to be_able_to([:display, :update], subscription, subscription.guest_token)
     end
 
-    it "is allowed to manage someone else's subscriptions" do
+    it "is not allowed to display or update someone else's subscriptions" do
       subscription = create(:subscription)
 
       ability = Spree::Ability.new(nil)
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).not_to be_able_to(:manage, subscription, 'invalid')
+      expect(ability).not_to be_able_to([:display, :update], subscription, 'invalid')
     end
 
-    it 'is allowed to manage line items on their subscriptions' do
+    it 'is allowed to display and update line items on their subscriptions' do
       subscription = create(:subscription)
       line_item = create(:subscription_line_item, subscription: subscription)
 
@@ -78,10 +78,10 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).to be_able_to(:manage, line_item, subscription.guest_token)
+      expect(ability).to be_able_to([:display, :update], line_item, subscription.guest_token)
     end
 
-    it "is not allowed to manage line items on someone else's subscriptions" do
+    it "is not allowed to display or update line items on someone else's subscriptions" do
       subscription = create(:subscription)
       line_item = create(:subscription_line_item, subscription: subscription)
 
@@ -89,7 +89,7 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).not_to be_able_to(:manage, line_item, 'invalid')
+      expect(ability).not_to be_able_to([:display, :update], line_item, 'invalid')
     end
   end
 end


### PR DESCRIPTION
Fixes an issue with the DefaultCustomer permission set, which allowed guest users to access the subscription admin page (although they wouldn't have access to any subscriptions).