### PR TITLE
Add Subscriptions tab to User page in Admin

### DIFF
--- a/app/controllers/spree/admin/users/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/users/subscriptions_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    module Users
+      class SubscriptionsController < ResourceController
+        belongs_to 'spree/user', model_class: Spree.user_class
+
+        private
+
+        def model_class
+          ::SolidusSubscriptions::Subscription
+        end
+      end
+    end
+  end
+end

--- a/app/overrides/views/admin_users_subscriptions_tab.rb
+++ b/app/overrides/views/admin_users_subscriptions_tab.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Deface::Override.new(
+  virtual_path: 'spree/admin/users/_tabs',
+  name: 'solidus_subscriptions_admin_users_subscriptions_tab',
+  insert_bottom: "[data-hook='admin_user_tab_options']",
+  partial: 'spree/admin/users/subscription_tab'
+)

--- a/app/views/spree/admin/shared/_subscription_tab.html.erb
+++ b/app/views/spree/admin/shared/_subscription_tab.html.erb
@@ -1,3 +1,3 @@
 <% if can? :admin, SolidusSubscriptions::Subscription %>
-  <%= tab :subscriptions, icon: 'repeat' %>
+  <%= tab :subscriptions, icon: 'repeat', match_path: '/subscriptions' %>
 <% end %>

--- a/app/views/spree/admin/users/_subscription_tab.html.erb
+++ b/app/views/spree/admin/users/_subscription_tab.html.erb
@@ -1,0 +1,5 @@
+<% if can? :admin, @user.subscriptions %>
+  <li<%== ' class="active"' if current == :subscriptions %>>
+    <%= link_to t("spree.admin.user.subscriptions"), spree.admin_user_subscriptions_path(@user) %>
+  </li>
+<% end %>

--- a/app/views/spree/admin/users/subscriptions/index.html.erb
+++ b/app/views/spree/admin/users/subscriptions/index.html.erb
@@ -1,0 +1,44 @@
+<% admin_breadcrumb(link_to plural_resource_name(Spree::LegacyUser), spree.admin_users_path) %>
+<% admin_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
+<% admin_breadcrumb(plural_resource_name(SolidusSubscriptions::Subscription)) %>
+
+<%= render 'spree/admin/users/sidebar' %>
+<%= render 'spree/admin/users/tabs', current: :subscriptions %>
+
+<fieldset>
+  <legend><%= plural_resource_name(SolidusSubscriptions::Subscription) %></legend>
+
+  <% if @subscriptions.any? %>
+    <table id="subscriptions-table" class="index">
+      <thead>
+        <tr>
+          <th><%= SolidusSubscriptions::Subscription.human_attribute_name(:created_at) %></th>
+          <th><%= SolidusSubscriptions::Subscription.human_attribute_name(:actionable_date) %></th>
+          <th><%= SolidusSubscriptions::Subscription.human_attribute_name(:interval) %></th>
+          <th><%= SolidusSubscriptions::Subscription.human_attribute_name(:state) %></th>
+          <th><%= SolidusSubscriptions::Subscription.human_attribute_name(:processing_state) %></th>
+          <th class="actions"></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @subscriptions.each do |subscription| %>
+          <tr>
+            <td><%= l(subscription.created_at.to_date) %></td>
+            <td><%= subscription.actionable_date ? l(subscription.actionable_date.to_date) : '-' %></td>
+            <td><%= subscription.interval.inspect %></td>
+            <td><%= render 'spree/admin/subscriptions/state_pill', subscription: subscription %></td>
+            <td><%= render 'spree/admin/subscriptions/processing_state_pill', subscription: subscription %></td>
+            <td class="actions">
+              <%= link_to_edit(subscription, no_text: true, url: edit_admin_subscription_path(subscription)) %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class="no-objects-found">
+      <%= render 'spree/admin/shared/no_objects_found', resource: SolidusSubscriptions::Subscription %>
+    </div>
+  <% end %>
+</fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,8 @@ en:
       subscription_events:
         index:
           title: Events
+      user:
+        subscriptions: Subscriptions
     promotion_rule_types:
       subscription_promotion_rule:
         name: Subscription

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,5 +25,9 @@ Spree::Core::Engine.routes.draw do
       resources :installments, only: [:index, :show]
       resources :subscription_events, only: :index
     end
+
+    resources :users do
+      resources :subscriptions, only: [:index], controller: 'users/subscriptions'
+    end
   end
 end

--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -43,7 +43,8 @@ module SolidusSubscriptions
           [:subscriptions],
           'repeat',
           url: :admin_subscriptions_path,
-          condition: ->{ can?(:admin, SolidusSubscriptions::Subscription) }
+          condition: ->{ can?(:admin, SolidusSubscriptions::Subscription) },
+          match_path: '/subscriptions'
         )
       end
     end

--- a/spec/features/admin_users_subscription_tabs_spec.rb
+++ b/spec/features/admin_users_subscription_tabs_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe 'User subscriptions tab', type: :feature do
+  stub_authorization!
+
+  let(:user) { create(:user) }
+
+  before do
+    allow(Spree.user_class).to receive(:find_by).
+      with(hash_including(:id)).
+      and_return(user)
+  end
+
+  context 'when user has subscriptions' do
+    let!(:subscription) {
+      create(:subscription,
+        actionable_date: '2020-10-21',
+        interval_length: 10,
+        interval_units: :day,
+        user: user)
+    }
+
+    before do
+      visit '/admin/'
+      click_link 'Users'
+      click_link subscription.user.email
+      within('.tabs') { click_link 'Subscriptions' }
+    end
+
+    it 'lists user subscriptions' do
+      subscriptions_table = page.find('#subscriptions-table')
+
+      expect(subscriptions_table).to have_content('2020-10-21')
+      expect(subscriptions_table).to have_content('10 days')
+    end
+
+    it 'shows edit link to subscriptions' do
+      page.find("#subscriptions-table td.actions a.fa-edit").click
+
+      expect(page).to have_current_path spree.edit_admin_subscription_path(subscription), ignore_query: true
+    end
+  end
+
+  context 'when user does not have subscriptions' do
+    it 'displays no found message when user has no subscriptions' do
+      visit spree.admin_path
+      click_link 'Users'
+      click_link user.email
+      within('.tabs') { click_link 'Subscriptions' }
+
+      expect(page).to have_content('No Subscriptions found.')
+    end
+  end
+end


### PR DESCRIPTION
It adds a simplified version of the Subscription list to the user's show page. This is intended to make it easier to list user's subscriptions when accessing their pages.

<img width="1012" alt="users-subscriptions" src="https://user-images.githubusercontent.com/2119750/97599425-be407580-19e6-11eb-9a78-447f5fb2763e.png">
