### PR TITLE
Move maximum reprocessing retries to a time based criterion

### DIFF
--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -241,6 +241,14 @@ module SolidusSubscriptions
       billing_address || user.bill_address
     end
 
+    def last_fulfilled_at
+      SolidusSubscriptions::InstallmentDetail.joins(installment: :subscription)
+                                             .where('subscription_id = ?', id)
+                                             .where(success: true)
+                                             .order('created_at DESC')
+                                             .first&.created_at
+    end
+
     private
 
     def check_successive_skips_exceeded

--- a/lib/generators/solidus_subscriptions/install/templates/initializer.rb
+++ b/lib/generators/solidus_subscriptions/install/templates/initializer.rb
@@ -22,9 +22,9 @@ SolidusSubscriptions.configure do |config|
   # Time between an installment failing to be processed and the system retrying to fulfill it.
   # config.reprocessing_interval = 1.day
 
-  # Maximum number of times the system attempts to reprocess a failed payment before cancelling
-  # the subscription (`nil` is the default and will make the system reprocess indefinitely).
-  # config.maximum_reprocessing_attempts = nil
+  # Maximum time that can pass after the last succesfull subscription installment to make a payment
+  # failure cancel the subscription.
+  # config.maximum_reprocessing_time = nil
 
   # ========================================= Dispatchers ==========================================
   #

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -3,7 +3,7 @@
 module SolidusSubscriptions
   class Configuration
     attr_accessor(
-      :maximum_total_skips, :maximum_reprocessing_attempts, :churn_buster_account_id,
+      :maximum_total_skips, :maximum_reprocessing_time, :churn_buster_account_id,
       :churn_buster_api_key, :clear_past_installments,
     )
 

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -607,4 +607,30 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
       end
     end
   end
+
+  describe '#last_fulfilled_at' do
+    context 'when the subscription has never been fulfilled' do
+      it 'returns nil' do
+        subscription = create(:subscription, installments: [
+          create(:installment, details: [create(:installment_detail, success: false, created_at: '2020-11-11')]),
+          create(:installment, details: [create(:installment_detail, success: false, created_at: '2020-11-24')]),
+        ])
+
+        expect(subscription.last_fulfilled_at).to eq(nil)
+      end
+    end
+
+    context 'when the subscription has been fulfilled at least one time' do
+      it 'returns the last successful fulfillment date' do
+        subscription = create(:subscription, installments: [
+          create(:installment, details: [create(:installment_detail, :success, created_at: '2020-11-11')]),
+          create(:installment, details: [create(:installment_detail, :success, created_at: '2020-11-15')]),
+          create(:installment, details: [create(:installment_detail, :success, created_at: '2020-11-20')]),
+          create(:installment, details: [create(:installment_detail, success: false, created_at: '2020-11-24')]),
+        ])
+
+        expect(subscription.last_fulfilled_at).to eq(Time.zone.parse('2020-11-20'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
This changes the logic used to determine whether a subscription should be canceled after consecutive payment failures. Previously it was based on a maximum number of attempts per installment, however it makes sense to have it based on the time passed since the last succesful installment.

This makes it also play nice with the [new configuration](https://github.com/solidusio-contrib/solidus_subscriptions/commit/b3dc679b7056931397820ad333686ef151656ba4) to clear past failed installments, which could render the maximum attempts useless, since there could have been situations where the maximum attempts number would never be reached. Switching to time based criteria makes this simpler and more predictable.