### PR TITLE
Fix automatic cancellation in case of subscription failure

### DIFF
--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -116,7 +116,7 @@ module SolidusSubscriptions
         message: I18n.t('solidus_subscriptions.installment_details.payment_failed')
       )
 
-      if maximum_reprocessing_time_reached? && !subscription.canceled?
+      if subscription.maximum_reprocessing_time_reached? && !subscription.canceled?
         subscription.force_cancel!
         update!(actionable_date: nil)
       else
@@ -125,14 +125,6 @@ module SolidusSubscriptions
     end
 
     private
-
-    # Returns whether this installment has failed after the maximum reprocessing time.
-    def maximum_reprocessing_time_reached?
-      return false unless SolidusSubscriptions.configuration.maximum_reprocessing_time
-      return false unless subscription.last_fulfilled_at
-
-      subscription.last_fulfilled_at + SolidusSubscriptions.configuration.maximum_reprocessing_time < Time.zone.now
-    end
 
     def advance_actionable_date!
       update!(actionable_date: next_actionable_date)

--- a/app/models/solidus_subscriptions/installment_detail.rb
+++ b/app/models/solidus_subscriptions/installment_detail.rb
@@ -15,6 +15,9 @@ module SolidusSubscriptions
     validates :installment, presence: true
     alias_attribute :successful, :success
 
+    scope :succeeded, -> { where success: true }
+    scope :failed, -> { where success: false }
+
     # Was the attempt at fulfilling this installment a failure?
     #
     # @return [Boolean]

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -110,8 +110,7 @@ RSpec.describe SolidusSubscriptions::Processor, :checkout do
 
     context "when the config 'clear_past_installments' is enabled" do
       it 'clears the past failed installments' do
-        allow(SolidusSubscriptions.configuration).to receive(:clear_past_installments).
-          and_return(true)
+        stub_config(clear_past_installments: true)
 
         subject
 

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -92,9 +92,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     end
 
     context 'the reprocessing interval is set to nil' do
-      before do
-        allow(SolidusSubscriptions.configuration).to receive_messages(reprocessing_interval: nil)
-      end
+      before { stub_config(reprocessing_interval: nil) }
 
       it 'does not advance the installment actionable_date' do
         subject
@@ -188,7 +186,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
       it "advances the installment's actionable_date" do
         subscription = create(:subscription)
         allow(subscription).to receive(:maximum_reprocessing_time_reached?).and_return(false)
-        allow(SolidusSubscriptions.configuration).to receive(:reprocessing_interval).and_return(2.days)
+        stub_config(reprocessing_interval: 2.days)
 
         current_installment = create(:installment, subscription: subscription)
         current_installment.payment_failed!(create(:order))

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -141,138 +141,69 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
   end
 
   describe '#payment_failed!' do
-    context 'when maximum_reprocessing_time is nil' do
+    context 'when the maximum reprocessing time has been reached' do
       it 'creates a new installment detail' do
-        allow(SolidusSubscriptions.configuration).to receive_messages(
-          maximum_reprocessing_time: nil,
-          reprocessing_interval: 2.days,
-        )
-        installment = create(:installment)
+        subscription = create(:subscription)
+        allow(subscription).to receive(:maximum_reprocessing_time_reached?).and_return(true)
 
-        installment.payment_failed!(create(:order))
+        current_installment = create(:installment, subscription: subscription)
+        current_installment.payment_failed!(create(:order))
 
-        expect(installment.details.count).to eq(1)
+        expect(current_installment.details.count).to eq(1)
       end
 
-      it "advances the installment's actionable_date" do
-        allow(SolidusSubscriptions.configuration).to receive_messages(
-          maximum_reprocessing_time: nil,
-          reprocessing_interval: 2.days,
-        )
-        installment = create(:installment)
+      it 'sets the actionable_date to nil' do
+        subscription = create(:subscription)
+        allow(subscription).to receive(:maximum_reprocessing_time_reached?).and_return(true)
 
-        installment.payment_failed!(create(:order))
+        current_installment = create(:installment, subscription: subscription)
+        current_installment.payment_failed!(create(:order))
 
-        expect(installment.actionable_date).to eq((Time.zone.now + 2.days).beginning_of_minute)
+        expect(current_installment.actionable_date).to eq(nil)
+      end
+
+      it 'cancels the subscription' do
+        subscription = create(:subscription)
+        allow(subscription).to receive(:maximum_reprocessing_time_reached?).and_return(true)
+
+        current_installment = create(:installment, subscription: subscription)
+        current_installment.payment_failed!(create(:order))
+
+        expect(current_installment.subscription.state).to eq('canceled')
       end
     end
 
-    context 'when maximum_reprocessing_attempts is configured' do
-      context 'when the installment has surpassed the maximum reprocessing time' do
-        it 'creates a new installment detail' do
-          allow(SolidusSubscriptions.configuration).to receive_messages(
-            maximum_reprocessing_time: 3.days,
-            reprocessing_interval: 2.days,
-          )
-          subscription = create(:subscription)
-          _last_successful_installment = create(
-            :installment,
-            subscription: subscription,
-            details: [create(:installment_detail, :success, created_at: 4.days.ago)]
-          )
-          current_installment = create(:installment, subscription: subscription)
-          current_installment.payment_failed!(create(:order))
+    context 'when the maximum reprocessing time has not been reached' do
+      it 'creates a new installment detail' do
+        subscription = create(:subscription)
+        allow(subscription).to receive(:maximum_reprocessing_time_reached?).and_return(false)
 
-          expect(current_installment.details.count).to eq(1)
-        end
+        current_installment = create(:installment, subscription: subscription)
+        current_installment.payment_failed!(create(:order))
+        current_installment.payment_failed!(create(:order))
 
-        it 'sets the actionable_date to nil' do
-          allow(SolidusSubscriptions.configuration).to receive_messages(
-            maximum_reprocessing_time: 3.days,
-            reprocessing_interval: 2.days,
-          )
-          subscription = create(:subscription)
-          _last_successful_installment = create(
-            :installment,
-            subscription: subscription,
-            details: [create(:installment_detail, :success, created_at: 4.days.ago)]
-          )
-          current_installment = create(:installment, subscription: subscription)
-          current_installment.payment_failed!(create(:order))
-
-          expect(current_installment.actionable_date).to eq(nil)
-        end
-
-        it 'cancels the subscription' do
-          allow(SolidusSubscriptions.configuration).to receive_messages(
-            maximum_reprocessing_time: 3.days,
-            reprocessing_interval: 2.days,
-          )
-          subscription = create(:subscription)
-          _last_successful_installment = create(
-            :installment,
-            subscription: subscription,
-            details: [create(:installment_detail, :success, created_at: 4.days.ago)]
-          )
-          current_installment = create(:installment, subscription: subscription)
-          current_installment.payment_failed!(create(:order))
-
-          expect(current_installment.subscription.state).to eq('canceled')
-        end
+        expect(current_installment.details.count).to eq(2)
       end
 
-      context 'when the installment has not surpassed the maximum reprocessing time' do
-        it 'creates a new installment detail' do
-          allow(SolidusSubscriptions.configuration).to receive_messages(
-            maximum_reprocessing_time: 3.days,
-            reprocessing_interval: 2.days,
-          )
-          subscription = create(:subscription)
-          _last_successful_installment = create(
-            :installment,
-            subscription: subscription,
-            details: [create(:installment_detail, :success, created_at: 1.day.ago)]
-          )
-          current_installment = create(:installment, subscription: subscription)
-          current_installment.payment_failed!(create(:order))
-          current_installment.payment_failed!(create(:order))
+      it "advances the installment's actionable_date" do
+        subscription = create(:subscription)
+        allow(subscription).to receive(:maximum_reprocessing_time_reached?).and_return(false)
+        allow(SolidusSubscriptions.configuration).to receive(:reprocessing_interval).and_return(2.days)
 
-          expect(current_installment.details.count).to eq(2)
-        end
+        current_installment = create(:installment, subscription: subscription)
+        current_installment.payment_failed!(create(:order))
 
-        it "advances the installment's actionable_date" do
-          allow(SolidusSubscriptions.configuration).to receive_messages(
-            maximum_reprocessing_time: 3.days,
-            reprocessing_interval: 2.days,
-          )
-          subscription = create(:subscription)
-          _last_successful_installment = create(
-            :installment,
-            subscription: subscription,
-            details: [create(:installment_detail, :success, created_at: 1.day.ago)]
-          )
-          current_installment = create(:installment, subscription: subscription)
-          current_installment.payment_failed!(create(:order))
+        expect(current_installment.actionable_date).to eq((Time.zone.now + 2.days).beginning_of_minute)
+      end
 
-          expect(current_installment.actionable_date).to eq((Time.zone.now + 2.days).beginning_of_minute)
-        end
+      it 'does not cancel the subscription' do
+        subscription = create(:subscription)
+        allow(subscription).to receive(:maximum_reprocessing_time_reached?).and_return(false)
 
-        it 'does not cancel the subscription' do
-          allow(SolidusSubscriptions.configuration).to receive_messages(
-            maximum_reprocessing_time: 3.days,
-            reprocessing_interval: 2.days,
-          )
-          subscription = create(:subscription)
-          _last_successful_installment = create(
-            :installment,
-            subscription: subscription,
-            details: [create(:installment_detail, :success, created_at: 1.day.ago)]
-          )
-          current_installment = create(:installment, subscription: subscription)
-          current_installment.payment_failed!(create(:order))
+        current_installment = create(:installment, subscription: subscription)
+        current_installment.payment_failed!(create(:order))
 
-          expect(subscription.state).to eq('active')
-        end
+        expect(subscription.state).to eq('active')
       end
     end
   end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -675,9 +675,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
   describe '#maximum_reprocessing_time_reached?' do
     context 'when maximum_reprocessing_time is not configured' do
       it 'returns false' do
-        allow(SolidusSubscriptions.configuration).to receive_messages(
-          maximum_reprocessing_time: 5.days,
-        )
+        stub_config(maximum_reprocessing_time: 5.days)
         subscription = create(:subscription)
 
         expect(subscription.maximum_reprocessing_time_reached?).to eq(false)
@@ -687,9 +685,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
     context 'when maximum_reprocessing_time is configured' do
       context 'when the subscription has been failing for too long' do
         it 'returns true' do
-          allow(SolidusSubscriptions.configuration).to receive_messages(
-            maximum_reprocessing_time: 15.days,
-          )
+          stub_config(maximum_reprocessing_time: 15.days)
 
           subscription = create(:subscription, installments: [
             create(:installment, details: [
@@ -713,9 +709,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
       context 'when the subscription has not been failing for too long' do
         it 'returns false' do
-          allow(SolidusSubscriptions.configuration).to receive_messages(
-            maximum_reprocessing_time: 15.days,
-          )
+          stub_config(maximum_reprocessing_time: 15.days)
 
           subscription = create(:subscription, installments: [
             create(:installment, details: [
@@ -739,9 +733,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
       context 'when the subscription is not failing' do
         it 'returns false' do
-          allow(SolidusSubscriptions.configuration).to receive_messages(
-            maximum_reprocessing_time: 2.days,
-          )
+          stub_config(maximum_reprocessing_time: 2.days)
 
           subscription = create(:subscription, installments: [
             create(:installment, details: [

--- a/spec/support/helpers/config.rb
+++ b/spec/support/helpers/config.rb
@@ -1,0 +1,13 @@
+module SolidusSubscriptions
+  module TestingSupport
+    module ConfigHelper
+      def stub_config(options)
+        allow(SolidusSubscriptions.configuration).to receive_messages(options)
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include SolidusSubscriptions::TestingSupport::ConfigHelper
+end


### PR DESCRIPTION
Fixes an issue with automatic subscription cancellation that was causing subscriptions to be cancelled ahead of time.

Rather than looking at the date of the first failed payment, we were looking at the date of the last successful payment. This means that, if a customer was on a 4-week cycle and a payment failed, the system would assume that payment had been failing for 4 weeks, where in fact it had just started failing.
    
The new implementation looks at the date of the first failed charge after the last successful charge, which is the behavior we expected.