### PR TITLE
Associate first order to subscription

### DIFF
--- a/app/services/solidus_subscriptions/subscription_generator.rb
+++ b/app/services/solidus_subscriptions/subscription_generator.rb
@@ -32,9 +32,12 @@ module SolidusSubscriptions
         **configuration.to_h
       }
 
-      Subscription.create!(subscription_attributes) do |sub|
+      subscription = Subscription.create!(subscription_attributes) do |sub|
         sub.actionable_date = sub.next_actionable_date
       end
+      order.update!(subscription: subscription)
+
+      subscription
     end
 
     # Group a collection of line items by common subscription configuration

--- a/spec/services/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/services/solidus_subscriptions/subscription_generator_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
         payment_source: payment_source,
       )
     end
+
+    it 'associates the order to the subscription' do
+      subscription_line_item = build(:subscription_line_item)
+
+      subscription = described_class.activate([subscription_line_item])
+
+      expect(subscription_line_item.order.subscription).to eq(subscription)
+    end
   end
 
   describe '.group' do


### PR DESCRIPTION
As introduced by an earlier PR (#147), orders were linked back to subscriptions, however that missed to associate the first order because that particular one is generated in a different service object. This adds the aforementioned association also on the first order.