### PR TITLE
Remove time component from actionable_date columns

### DIFF
--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -24,7 +24,7 @@ module SolidusSubscriptions
     end)
 
     scope :actionable, (lambda do
-      unfulfilled.where("#{table_name}.actionable_date <= ?", Time.zone.now)
+      unfulfilled.where("#{table_name}.actionable_date <= ?", Time.zone.today)
     end)
 
     # Get the builder for the subscription_line_item. This will be an

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -40,7 +40,7 @@ module SolidusSubscriptions
     # Find all subscriptions that are "actionable"; that is, ones that have an
     # actionable_date in the past and are not invalid or canceled.
     scope :actionable, (lambda do
-      where("#{table_name}.actionable_date <= ?", Time.zone.now).
+      where("#{table_name}.actionable_date <= ?", Time.zone.today).
         where.not(state: ["canceled", "inactive"])
     end)
 

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -186,8 +186,9 @@ module SolidusSubscriptions
     def next_actionable_date
       return nil unless active?
 
-      new_date = (actionable_date || Time.zone.now)
-      (new_date + interval).beginning_of_minute
+      new_date = actionable_date || Time.zone.today
+
+      new_date + interval
     end
 
     # Advance the actionable date to the next_actionable_date value. Will modify

--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -119,7 +119,7 @@
         <tr>
           <td><%= l(subscription.created_at.to_date) %></td>
           <td><%= link_to subscription.user.email, admin_user_path(subscription.user) %></td>
-          <td><%= subscription.actionable_date ? l(subscription.actionable_date.to_date) : '-' %></td>
+          <td><%= subscription.actionable_date ? l(subscription.actionable_date) : '-' %></td>
           <td><%= subscription.interval.inspect %></td>
           <td><%= render 'state_pill', subscription: subscription %></td>
           <td><%= render 'processing_state_pill', subscription: subscription %></td>

--- a/app/views/spree/admin/users/subscriptions/index.html.erb
+++ b/app/views/spree/admin/users/subscriptions/index.html.erb
@@ -25,7 +25,7 @@
         <% @subscriptions.each do |subscription| %>
           <tr>
             <td><%= l(subscription.created_at.to_date) %></td>
-            <td><%= subscription.actionable_date ? l(subscription.actionable_date.to_date) : '-' %></td>
+            <td><%= subscription.actionable_date ? l(subscription.actionable_date) : '-' %></td>
             <td><%= subscription.interval.inspect %></td>
             <td><%= render 'spree/admin/subscriptions/state_pill', subscription: subscription %></td>
             <td><%= render 'spree/admin/subscriptions/processing_state_pill', subscription: subscription %></td>

--- a/db/migrate/20201123171026_change_actionable_date_to_date.rb
+++ b/db/migrate/20201123171026_change_actionable_date_to_date.rb
@@ -1,0 +1,15 @@
+class ChangeActionableDateToDate < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        change_column :solidus_subscriptions_subscriptions, :actionable_date, :date
+        change_column :solidus_subscriptions_installments, :actionable_date, :date
+      end
+
+      dir.down do
+        change_column :solidus_subscriptions_subscriptions, :actionable_date, :datetime
+        change_column :solidus_subscriptions_installments, :actionable_date, :datetime
+      end
+    end
+  end
+end

--- a/spec/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscrptions_spec.rb
+++ b/spec/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscrptions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SolidusSubscriptions::Spree::Order::FinalizeCreatesSubscriptions 
 
     let(:order) { create :order, :with_subscription_line_items }
     let(:subscription_line_item) { order.subscription_line_items.last }
-    let(:expected_actionable_date) { (DateTime.current + subscription_line_item.interval).beginning_of_minute }
+    let(:expected_actionable_date) { Time.zone.today + subscription_line_item.interval }
 
     around { |e| Timecop.freeze { e.run } }
 

--- a/spec/models/solidus_subscriptions/installment_spec.rb
+++ b/spec/models/solidus_subscriptions/installment_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     subject { installment.out_of_stock }
 
     let(:expected_date) do
-      (DateTime.current + SolidusSubscriptions.configuration.reprocessing_interval).beginning_of_minute
+      Time.zone.today + SolidusSubscriptions.configuration.reprocessing_interval
     end
 
     it { is_expected.to be_a SolidusSubscriptions::InstallmentDetail }
@@ -72,7 +72,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
     let(:order) { create :order }
 
     let(:expected_date) do
-      (DateTime.current + SolidusSubscriptions.configuration.reprocessing_interval).beginning_of_minute
+      Time.zone.today + SolidusSubscriptions.configuration.reprocessing_interval
     end
 
     it { is_expected.to be_a SolidusSubscriptions::InstallmentDetail }
@@ -191,7 +191,7 @@ RSpec.describe SolidusSubscriptions::Installment, type: :model do
         current_installment = create(:installment, subscription: subscription)
         current_installment.payment_failed!(create(:order))
 
-        expect(current_installment.actionable_date).to eq((Time.zone.now + 2.days).beginning_of_minute)
+        expect(current_installment.actionable_date).to eq(Time.zone.today + 2.days)
       end
 
       it 'does not cancel the subscription' do

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -569,7 +569,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
           subscription.update!(interval_length: 1, interval_units: 'month')
 
-          expect(subscription.actionable_date.to_date).to eq(Time.zone.today)
+          expect(subscription.actionable_date).to eq(Time.zone.today)
         end
       end
 
@@ -580,7 +580,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
           subscription.update!(interval_length: 1, interval_units: 'month')
 
-          expect(subscription.actionable_date.to_date).to eq((4.days.ago + 1.month).to_date)
+          expect(subscription.actionable_date).to eq((4.days.ago + 1.month).to_date)
         end
       end
     end
@@ -592,7 +592,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
           subscription.update!(interval_length: 1, interval_units: 'month')
 
-          expect(subscription.actionable_date.to_date).to eq(Time.zone.today)
+          expect(subscription.actionable_date).to eq(Time.zone.today)
         end
       end
 
@@ -602,7 +602,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
           subscription.update!(interval_length: 1, interval_units: 'month')
 
-          expect(subscription.actionable_date.to_date).to eq((4.days.ago + 1.month).to_date)
+          expect(subscription.actionable_date).to eq((4.days.ago + 1.month).to_date)
         end
       end
     end

--- a/spec/services/solidus_subscriptions/checkout_spec.rb
+++ b/spec/services/solidus_subscriptions/checkout_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe SolidusSubscriptions::Checkout do
 
     context 'the variant is out of stock' do
       let(:subscription_line_item) { installments.last.subscription.line_items.first }
-      let(:expected_date) { (DateTime.current + SolidusSubscriptions.configuration.reprocessing_interval).beginning_of_minute }
+      let(:expected_date) { Time.zone.today + SolidusSubscriptions.configuration.reprocessing_interval }
 
       # Remove stock for 1 variant in the consolidated installment
       before do
@@ -181,7 +181,7 @@ RSpec.describe SolidusSubscriptions::Checkout do
         checkout.user.wallet.default_wallet_payment_source = wallet_payment_source
         card
       }
-      let(:expected_date) { (DateTime.current + SolidusSubscriptions.configuration.reprocessing_interval).beginning_of_minute }
+      let(:expected_date) { Time.zone.today + SolidusSubscriptions.configuration.reprocessing_interval }
 
       it { is_expected.to be_nil }
 
@@ -237,7 +237,7 @@ RSpec.describe SolidusSubscriptions::Checkout do
     end
 
     context 'there is an aribitrary failure' do
-      let(:expected_date) { (DateTime.current + SolidusSubscriptions.configuration.reprocessing_interval).beginning_of_minute }
+      let(:expected_date) { Time.zone.today + SolidusSubscriptions.configuration.reprocessing_interval }
 
       before do
         allow(checkout).to receive(:populate).and_raise('arbitrary runtime error')


### PR DESCRIPTION
Removes the time component from the actionable_date column, both on subscriptions and installments. This can easily create bugs where the actionable_date of a subscription or installment is equal to the current date, but the time is in the future, and that causes the subscription/installment not to be processed.