### PR TITLE
Update cancel method on subscription to respect minimum date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'rails', '>0.a'
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 
+gem 'canonical-rails', '0.2.9'
+
 case ENV['DB']
 when 'mysql'
   gem 'mysql2'

--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ SolidusSubscriptions.configure do |config|
 end
 ```
 
+### Minimum cancellation notice
+
+The minimum cancellation notice is set to 0 days by default - users can cancel their subscription whenever they like. To change this, you can configure the extension like this:
+
+```ruby
+SolidusSubscriptions.configure do |config|
+  # ...
+
+  config.minimum_cancellation_notice = 10.days
+end
+```
+
 ## Development
 
 ### Testing the extension

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -150,7 +150,8 @@ module SolidusSubscriptions
     def can_be_canceled?
       return true if actionable_date.nil?
 
-      (actionable_date - SolidusSubscriptions.configuration.minimum_cancellation_notice).future?
+      cancel_by = actionable_date - SolidusSubscriptions.configuration.minimum_cancellation_notice
+      cancel_by.future? || cancel_by.today?
     end
 
     def skip(check_skip_limits: true)

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -43,7 +43,7 @@ module SolidusSubscriptions
     end
 
     def minimum_cancellation_notice
-      @minimum_cancellation_notice ||= 1.day
+      @minimum_cancellation_notice ||= 0.days
     end
 
     def processing_queue

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -87,8 +87,13 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
     around { |e| Timecop.freeze { e.run } }
 
+    before do
+      allow(SolidusSubscriptions.configuration).to receive(:minimum_cancellation_notice) { minimum_cancellation_notice }
+    end
+
     context 'the subscription can be canceled' do
       let(:actionable_date) { 1.month.from_now }
+      let(:minimum_cancellation_notice) { 1.day }
 
       it 'is canceled' do
         subject
@@ -103,6 +108,7 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
     context 'the subscription cannot be canceled' do
       let(:actionable_date) { Date.current }
+      let(:minimum_cancellation_notice) { 1.day }
 
       it 'is pending cancelation' do
         subject
@@ -112,6 +118,16 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
       it 'creates a subscription_canceled event' do
         subject
         expect(subscription.events.last).to have_attributes(event_type: 'subscription_canceled')
+      end
+    end
+
+    context 'when the minimum cancellation date is 0.days' do
+      let(:actionable_date) { Date.current }
+      let(:minimum_cancellation_notice) { 0.days }
+
+      it 'is canceled' do
+        subject
+        expect(subscription).to be_canceled
       end
     end
   end


### PR DESCRIPTION
Previously, the cancel method would add one day to your
minimum_cancellation_date. This updates that! More info here:
https://github.com/solidusio-contrib/solidus_subscriptions/issues/177