### PR TITLE
Avoid processing installments with cancelled subscriptions

### DIFF
--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -23,6 +23,10 @@ module SolidusSubscriptions
       where.not(id: fulfilled_ids).distinct
     end)
 
+    scope :with_active_subscription, (lambda do
+      joins(:subscription).where.not(Subscription.table_name => {state: "canceled"})
+    end)
+
     scope :actionable, (lambda do
       unfulfilled.where("#{table_name}.actionable_date <= ?", Time.zone.today)
     end)

--- a/lib/solidus_subscriptions/processor.rb
+++ b/lib/solidus_subscriptions/processor.rb
@@ -34,7 +34,7 @@ module SolidusSubscriptions
           ).
           where(
             SolidusSubscriptions::Subscription.actionable.arel.constraints.reduce(:and).
-              or(SolidusSubscriptions::Installment.actionable.arel.constraints.reduce(:and))
+              or(SolidusSubscriptions::Installment.actionable.with_active_subscription.arel.constraints.reduce(:and))
           ).
           distinct.
           find_in_batches

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -129,6 +129,17 @@ RSpec.describe SolidusSubscriptions::Processor, :checkout do
         expect { subject }.to change { Spree::Order.complete.count }.by 2
       end
     end
+
+    context 'the subscription is cancelled with pending installments' do
+      let!(:cancelled_installment) do
+        installment = create(:installment, actionable_date: Date.today)
+        installment.subscription.cancel!
+      end
+
+      it 'does not process the installment' do
+        expect { subject }.to change { Spree::Order.complete.count }.by expected_orders
+      end
+    end
   end
 
   describe '.run' do


### PR DESCRIPTION
Anyone who cancels their subscription with a failed installment will
still have an order created the next time installments are created.
This is because installments don't check the status of their associated
subscriptions before being processed.

This update will ensure that only active subscriptions are processed.

Ref: #180 