### PR TITLE
Add Installment Details association to Order

### DIFF
--- a/app/decorators/models/solidus_subscriptions/spree/order/installment_details_association.rb
+++ b/app/decorators/models/solidus_subscriptions/spree/order/installment_details_association.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusSubscriptions
+  module Spree
+    module Order
+      module InstallmentDetailsAssociation
+        def self.prepended(base)
+          base.has_many :installment_details, class_name: '::SolidusSubscriptions::InstallmentDetail'
+        end
+      end
+    end
+  end
+end
+
+Spree::Order.prepend(SolidusSubscriptions::Spree::Order::InstallmentDetailsAssociation)

--- a/spec/decorators/models/solidus_subscriptions/spree/order/installment_details_association_spec.rb
+++ b/spec/decorators/models/solidus_subscriptions/spree/order/installment_details_association_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe SolidusSubscriptions::Spree::Order::InstallmentDetailsAssociation, type: :model do
+  subject { Spree::Order.new }
+
+  it { is_expected.to have_many :installment_details }
+end


### PR DESCRIPTION
This is useful if you want to connect orders to installments - for
instance, if you wanted to get a list of orders for a user that
are part of an installment.