### PR TITLE
Update permissions check on user subscription tab

### DIFF
--- a/app/views/spree/admin/users/_subscription_tab.html.erb
+++ b/app/views/spree/admin/users/_subscription_tab.html.erb
@@ -1,4 +1,4 @@
-<% if can? :admin, @user.subscriptions %>
+<% if can? :admin, SolidusSubscriptions::Subscription.new(user: @user) %>
   <li<%== ' class="active"' if current == :subscriptions %>>
     <%= link_to t("spree.admin.user.subscriptions"), spree.admin_user_subscriptions_path(@user) %>
   </li>


### PR DESCRIPTION
Previously, it would check your permissions on an ActiveRecord
association - which would in most non-admin cases be false, even
if they had permissions to manage subscriptions. This changes the
check to return a new instance of the users subscriptions, so
people with manage subscriptions permissions will still be able
to view this tab, while also allowing for you to conditionally
allow/deny permissions based on what users subscriptions they
are attempting to view.