### PR TITLE
Remove "canonical-rails" from the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,6 @@ gem 'rails', '>0.a'
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 
-gem 'canonical-rails', '0.2.9'
-
 case ENV['DB']
 when 'mysql'
   gem 'mysql2'

--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -24,7 +24,7 @@ module SolidusSubscriptions
     end)
 
     scope :with_active_subscription, (lambda do
-      joins(:subscription).where.not(Subscription.table_name => {state: "canceled"})
+      joins(:subscription).where.not(Subscription.table_name => { state: "canceled" })
     end)
 
     scope :actionable, (lambda do

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe SolidusSubscriptions::Processor, :checkout do
 
     context 'the subscription is cancelled with pending installments' do
       let!(:cancelled_installment) do
-        installment = create(:installment, actionable_date: Date.today)
+        installment = create(:installment, actionable_date: Time.zone.today)
         installment.subscription.cancel!
       end
 


### PR DESCRIPTION
The `canonical-rails` was locked down to 0.2.9 because Solidus still used the `whitelisted_attributes` method but with the new version 0.2.10 it was renamed to `allowed_parameters` and it can be removed.

This fixes https://github.com/solidusio-contrib/solidus_subscriptions/issues/187.