### PR TITLE
Improve "unfulfilled" scope by adding subquery

### DIFF
--- a/app/models/solidus_subscriptions/installment.rb
+++ b/app/models/solidus_subscriptions/installment.rb
@@ -19,8 +19,7 @@ module SolidusSubscriptions
     end)
 
     scope :unfulfilled, (lambda do
-      fulfilled_ids = fulfilled.pluck(:id)
-      where.not(id: fulfilled_ids).distinct
+      where.not(id: Installment.fulfilled).distinct
     end)
 
     scope :with_active_subscription, (lambda do


### PR DESCRIPTION
`SolidusSubscriptions::Installment#unfulfilled` gets the list of fulfilled installments, loads them ALL into memory, and then performs a WHERE id NOT IN (...) to get the installments that were not fulfilled, this PR simplify the scope using a WHERE clause with a subquery.

This fixes #171.