### PR TITLE
Admin: expose the subscription orders

### DIFF
--- a/app/controllers/spree/admin/subscription_orders_controller.rb
+++ b/app/controllers/spree/admin/subscription_orders_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    class SubscriptionOrdersController < ResourceController
+      belongs_to 'subscription', model_class: SolidusSubscriptions::Subscription
+
+      def index
+        @search = collection.ransack((params[:q] || {}).reverse_merge(s: 'created_at desc'))
+
+        @subscription_orders = @search.result(distinct: true).
+                               page(params[:page]).
+                               per(params[:per_page] || 20)
+      end
+
+      private
+
+      def model_class
+        ::Spree::Order
+      end
+
+      def find_resource
+        parent.orders.find(params[:id])
+      end
+
+      def build_resource
+        parent.orders.build
+      end
+
+      def collection
+        parent.orders
+      end
+    end
+  end
+end

--- a/app/views/spree/admin/shared/_subscription_tabs.html.erb
+++ b/app/views/spree/admin/shared/_subscription_tabs.html.erb
@@ -10,6 +10,9 @@
       <li<%== ' class="active"' if current == :events %>>
         <%= link_to t("spree.admin.subscriptions.edit.events"), spree.admin_subscription_subscription_events_path(subscription) %>
       </li>
+      <li<%== ' class="active"' if current == :orders %>>
+        <%= link_to t("spree.admin.subscriptions.edit.orders"), spree.admin_subscription_subscription_orders_path(subscription) %>
+      </li>
     </ul>
   </nav>
 <% end %>

--- a/app/views/spree/admin/subscription_orders/index.html.erb
+++ b/app/views/spree/admin/subscription_orders/index.html.erb
@@ -1,0 +1,93 @@
+<% content_for(:page_title, t('.title')) %>
+
+<%= render 'spree/admin/shared/subscription_breadcrumbs', subscription: @subscription %>
+<%= render 'spree/admin/shared/subscription_sidebar', subscription: @subscription %>
+<%= render 'spree/admin/shared/subscription_tabs', current: :orders, subscription: @subscription %>
+<%= render 'spree/admin/shared/subscription_actions', subscription: @subscription %>
+
+<% content_for :table_filter_title do %>
+  <%= t('spree.filter') %>
+<% end %>
+
+<% content_for :table_filter do %>
+  <div data-hook="admin_orders_index_search">
+    <%= search_form_for [:admin, @search], url: admin_subscription_subscription_orders_path(@subscription) do |f| %>
+      <div class="row">
+        <div class="field-block col-12 col-md-6 col-lg-8">
+          <div class="date-range-filter field">
+            <%= label_tag :q_created_at_gt, t('spree.date_range') %>
+            <div class="date-range-fields input-group">
+              <%= f.text_field :created_at_gt, class: 'datepicker form-control datepicker-from', placeholder: t('spree.start') %>
+
+              <div class="input-group-prepend input-group-append">
+                <span class="input-group-text range-divider">
+                  <i class="fa fa-arrow-right"></i>
+                </span>
+              </div>
+
+              <%= f.text_field :created_at_lt, class: 'datepicker form-control datepicker-to', placeholder: t('spree.stop') %>
+            </div>
+          </div>
+        </div>
+        <div class="field-block col-12 col-md-6 col-lg-4">
+          <div class="field">
+            <%= label_tag :q_state_eq, t('spree.status') %>
+            <%= f.select :state_eq, Spree::Order.state_machines[:state].states.collect {|s| [t(s.name, scope: 'spree.order_state'), s.value]}, {include_blank: true}, class: 'custom-select fullwidth' %>
+          </div>
+        </div>
+      </div>
+
+      <div class="clearfix"></div>
+
+      <div class="actions filter-actions">
+        <div data-hook="admin_orders_index_search_buttons">
+          <%= button_tag t('spree.filter_results'), class: 'btn btn-primary' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<fieldset class="no-border-bottom">
+  <legend><%= t('spree.admin.subscription_orders.index.title') %></legend>
+
+  <%= paginate @subscription_orders, theme: 'solidus_admin' %>
+
+  <% if @subscription_orders.any? %>
+    <table id="listing_subscription_orders" class="index">
+      <thead>
+        <tr data-hook="admin_subscription_orders_index_headers">
+          <th><%= sort_link @search, :created_at %></th>
+          <th><%= sort_link @search, :number %></th>
+          <th><%= sort_link @search, :state %></th>
+          <th class="align-right"><%= sort_link @search, :total %></th>
+          <th data-hook="admin_orders_index_header_actions" class="actions"></th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @subscription_orders.each do |order| %>
+          <tr class="admin_subscription_order">
+            <td><%= l order.created_at.to_date %></td>
+            <td><%= link_to order.number, edit_admin_order_path(order) %></td>
+            <td>
+              <span class="pill pill-<%= order.state %>">
+                <%= t(order.state, scope: 'spree.order_state') %>
+              </span>
+            </td>
+            <td class="align-right"><%= order.display_total.to_html %></td>
+            <td class='actions align-center' data-hook="admin_orders_index_row_actions">
+              <%= link_to_edit_url edit_admin_order_path(order), title: "admin_edit_#{dom_id(order)}", no_text: true %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class="no-objects-found">
+      <%= render 'spree/admin/shared/no_objects_found', resource: Spree::Order %>
+    </div>
+  <% end %>
+
+  <%= paginate @subscription_orders, theme: 'solidus_admin' %>
+</fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
           installments: Installments
           events: Events
           payment: Payment
+          orders: Orders
         new:
           back: Back to Subscriptions List
           title: Create a Susbcription
@@ -56,6 +57,9 @@ en:
       subscription_events:
         index:
           title: Events
+      subscription_orders:
+        index:
+          title: Orders
       user:
         subscriptions: Subscriptions
     promotion_rule_types:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Spree::Core::Engine.routes.draw do
       post :skip, on: :member
       resources :installments, only: [:index, :show]
       resources :subscription_events, only: :index
+      resources :subscription_orders, path: :orders, only: :index
     end
 
     resources :users do

--- a/spec/features/admin/subscription_orders_spec.rb
+++ b/spec/features/admin/subscription_orders_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Subscription orders admin' do
+  stub_authorization!
+
+  let(:subscription) { create(:subscription, :with_shipping_address, :with_billing_address) }
+
+  before do
+    visit spree.edit_admin_subscription_path(subscription)
+    within('.tabs') { click_link 'Orders' }
+  end
+
+  it 'shows a No orders messages' do
+    expect(page).to have_css('legend', text: 'Orders')
+    expect(page).to have_content(/No orders found/i)
+  end
+
+  context 'with some orders' do
+    let(:orders) { build_list(:order, 3, subscription_order: true) }
+    let(:subscription) do
+      create(:subscription, :with_shipping_address, :with_billing_address).tap do |subscription|
+        subscription.orders << orders
+      end
+    end
+
+    it 'lists the orders of a subscription' do
+      expect(page).to have_css('.admin_subscription_order', count: orders.size)
+      within('#listing_subscription_orders') do
+        orders.each do |order|
+          expect(page).to have_content(order.number)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a new tab in the member view of subscriptions to list the orders
processed by the current subscription.

Closes #129 

### Screenshot
![orders](https://user-images.githubusercontent.com/6893256/107005846-98b6cb00-6790-11eb-92f1-c1da150e2b5b.png)
