### PR TITLE
Deprecate nested subscription attributes from user

### DIFF
--- a/app/decorators/models/solidus_subscriptions/spree/user/have_many_subscriptions.rb
+++ b/app/decorators/models/solidus_subscriptions/spree/user/have_many_subscriptions.rb
@@ -14,6 +14,14 @@ module SolidusSubscriptions
 
           base.accepts_nested_attributes_for :subscriptions
         end
+
+        def subscriptions_attributes=(params)
+          ::Spree::Deprecation.warn(
+            'Creating or updating subscriptions through Spree::User nested attributes is deprecated. ' \
+            'Please use subscriptions APIs directly.'
+          )
+          super
+        end
       end
     end
   end

--- a/spec/decorators/models/solidus_subscriptions/spree/user/have_many_subscriptions_spec.rb
+++ b/spec/decorators/models/solidus_subscriptions/spree/user/have_many_subscriptions_spec.rb
@@ -5,4 +5,16 @@ RSpec.describe SolidusSubscriptions::Spree::User::HaveManySubscriptions, type: :
 
   it { is_expected.to have_many :subscriptions }
   it { is_expected.to accept_nested_attributes_for :subscriptions }
+
+  describe '#subscriptions_attributes=' do
+    it 'throws a deprecation warning' do
+      allow(::Spree::Deprecation).to receive(:warn)
+
+      subject.subscriptions_attributes = [{ interval_length: 2 }]
+
+      expect(::Spree::Deprecation)
+        .to have_received(:warn)
+        .with(/Creating or updating subscriptions through Spree::User nested attributes is deprecated/)
+    end
+  end
 end

--- a/spec/decorators/models/solidus_subscriptions/spree/user/have_many_subscriptions_spec.rb
+++ b/spec/decorators/models/solidus_subscriptions/spree/user/have_many_subscriptions_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe SolidusSubscriptions::Spree::User::HaveManySubscritptions, type: :model do
+RSpec.describe SolidusSubscriptions::Spree::User::HaveManySubscriptions, type: :model do
   subject { Spree::User.new }
 
   it { is_expected.to have_many :subscriptions }


### PR DESCRIPTION
This PR comes as a temporary solution for #124. 

Since removing `Spree::User` subscriptions `nested_attributes` directly may cause problems to current users of the extension, they have just been deprecated right now, so that they can be removed from next releases.