### PR TITLE
Fix duplicated line items creation

### DIFF
--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -24,8 +24,7 @@ module Spree
 
       def update
         load_payment_methods
-
-        @subscription.assign_attributes(permitted_resource_params)
+        @subscription.payment_method_id = params[:subscription][:payment_method_id]
 
         if @subscription.payment_method&.source_required?
           @subscription.payment_source = @subscription

--- a/spec/controllers/spree/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/spree/admin/subscriptions_controller_spec.rb
@@ -42,20 +42,54 @@ RSpec.describe Spree::Admin::SubscriptionsController, type: :request do
   end
 
   describe 'PUT :update' do
-    subject { put spree.admin_subscription_path(subscription), params: subscription_params }
+    it 'redirects to edit subscription page' do
+      subscription = create :subscription
+      subscription_params = { subscription: { interval_length: 1 } }
 
-    let(:expected_date) { DateTime.parse('2001/11/12') }
-    let(:subscription) { create :subscription, :actionable }
-    let(:subscription_params) do
-      {
-        subscription: { actionable_date: expected_date }
-      }
+      expect(put(spree.admin_subscription_path(subscription), params: subscription_params)).
+        to redirect_to spree.edit_admin_subscription_path(subscription)
     end
 
-    it { is_expected.to redirect_to spree.edit_admin_subscription_path(subscription) }
-
     it 'updates the subscription attributes', :aggregate_failures do
-      expect { subject }.to change { subscription.reload.actionable_date }.to expected_date
+      expected_date = DateTime.parse('2001/11/12')
+      subscription = create :subscription, :actionable
+      subscription_params = { subscription: { actionable_date: expected_date } }
+
+      expect { put spree.admin_subscription_path(subscription), params: subscription_params }.
+        to change { subscription.reload.actionable_date }.
+        to expected_date
+    end
+
+    context 'when updating the payment method' do
+      it 'updates the subscription payment method' do
+        check_payment_method = create :check_payment_method
+        subscription = create :subscription
+        subscription_params = { subscription: { payment_method_id: check_payment_method.id } }
+
+        put spree.admin_subscription_path(subscription), params: subscription_params
+
+        expect(subscription.reload).to have_attributes(
+          payment_method: check_payment_method,
+          payment_source: nil,
+        )
+      end
+
+      it 'updates the subscription payment source if payment method requires source' do
+        subscription = create :subscription
+        payment = create :credit_card_payment
+        payment_source = payment.source
+        payment_method = payment.payment_method
+        subscription_params = {
+          subscription: {
+            payment_method_id: payment_method.id,
+            payment_source_id: payment_source.id,
+          }
+        }
+
+        put spree.admin_subscription_path(subscription), params: subscription_params
+
+        expect(subscription.reload.payment_source).to eq(payment_source)
+      end
     end
   end
 

--- a/spec/controllers/spree/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/spree/admin/subscriptions_controller_spec.rb
@@ -60,6 +60,22 @@ RSpec.describe Spree::Admin::SubscriptionsController, type: :request do
         to expected_date
     end
 
+    it 'does not duplicate line items' do
+      variant = create :variant, subscribable: true
+      subscription = create :subscription
+      subscription_params = {
+        subscription: {
+          line_items_attributes: [
+            { subscribable_id: variant.id, quantity: 1 }
+          ]
+        }
+      }
+
+      expect { put spree.admin_subscription_path(subscription), params: subscription_params }.
+        to change { subscription.reload.line_items.count }.
+        by 1
+    end
+
     context 'when updating the payment method' do
       it 'updates the subscription payment method' do
         check_payment_method = create :check_payment_method


### PR DESCRIPTION
Ref: #132 

When we update a subscription with new line items, the logic is assigning it twice. It's assigned in SubscriptionsController#update[1] and in ResourceController#update[2].

It only happened with new line items because there's no id for them.

[1] https://github.com/solidusio-contrib/solidus_subscriptions/blob/69f0ca038b66d0ca36971405e51c0d3aa916cf19/app/controllers/spree/admin/subscriptions_controller.rb#L28
[2] https://github.com/solidusio/solidus/blob/b0092d0f3bda447494a586bf8eb96a18322b8bed/backend/app/controllers/spree/admin/resource_controller.rb#L36