### PR TITLE
Fix sandbox creation error

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -67,7 +67,7 @@ unbundled bundle install --gemfile Gemfile
 
 unbundled bundle exec rake db:drop db:create
 
-unbundled bundle exec rails generate spree:install \
+unbundled bundle exec rails generate solidus:install \
   --auto-accept \
   --user_class=Spree::User \
   --enforce_available_locales=true \


### PR DESCRIPTION
I run `solidus extension .` (after running `bundle`) but kept only the change to `bin/sandbox`

Closes #196.