### PR TITLE
Use `name` in customer serializer

### DIFF
--- a/lib/solidus_subscriptions/churn_buster/subscription_customer_serializer.rb
+++ b/lib/solidus_subscriptions/churn_buster/subscription_customer_serializer.rb
@@ -9,10 +9,19 @@ module SolidusSubscriptions
           source_id: object.id,
           email: object.user.email,
           properties: {
-            first_name: object.shipping_address_to_use.firstname,
-            last_name: object.shipping_address_to_use.lastname,
+            name: name
           },
         }
+      end
+
+      private
+
+      def name
+        if ::Spree.solidus_gem_version < Gem::Version.new('2.11.0')
+          "#{object.shipping_address_to_use.first_name} #{object.shipping_address_to_use.last_name}"
+        else
+          object.shipping_address_to_use.name
+        end
       end
     end
   end


### PR DESCRIPTION
Solidus 3.0 removes `first_name` and `last_name` from `Spree::Address`
so we should replace them with `name`. The Churn Buster documentation
would suggest it's OK to pass any customer properties we need, but I
have yet to get a developer account to verify.

Leaving this in draft until I can verify with a Churn Buster developer account.

Closes #194.