### PR TITLE
Cleanup the duplicated fields on subscription creation

### DIFF
--- a/lib/solidus_subscriptions/subscription_generator.rb
+++ b/lib/solidus_subscriptions/subscription_generator.rb
@@ -34,6 +34,8 @@ module SolidusSubscriptions
 
       Subscription.create!(subscription_attributes) do |sub|
         sub.actionable_date = sub.next_actionable_date
+      end.tap do |_subscription|
+        cleanup_subscription_line_items(subscription_line_items)
       end
     end
 
@@ -53,6 +55,15 @@ module SolidusSubscriptions
     end
 
     private
+
+    def cleanup_subscription_line_items(subscription_line_items)
+      ids = subscription_line_items.pluck :id
+      SolidusSubscriptions::LineItem.where(id: ids).update_all(
+        interval_length: nil,
+        interval_units: nil,
+        end_date: nil
+      )
+    end
 
     def subscription_configuration(subscription_line_item)
       SubscriptionConfiguration.new(

--- a/spec/lib/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/lib/solidus_subscriptions/subscription_generator_spec.rb
@@ -46,12 +46,16 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
     end
 
     it 'cleanups the subscription line items fields duplicated on the subscription' do
-      subscription_line_item = create(:subscription_line_item)
+      attrs = { interval_length: 2, interval_units: :week, end_date: Time.zone.tomorrow }
+      subscription_line_item = create(:subscription_line_item, attrs)
 
       described_class.activate([subscription_line_item])
 
-      attrs = %i[interval_length interval_units end_date]
-      expect(subscription_line_item.reload.slice(attrs).values).to eq [nil, nil, nil]
+      expect(subscription_line_item.reload).to have_attributes(
+        interval_length: nil,
+        interval_units: nil,
+        end_date: nil
+      )
     end
   end
 

--- a/spec/lib/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/lib/solidus_subscriptions/subscription_generator_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
         payment_source: payment_source,
       )
     end
+
+    it 'cleanups the subscription line items fields duplicated on the subscription' do
+      subscription_line_item = create(:subscription_line_item)
+
+      described_class.activate([subscription_line_item])
+
+      attrs = %i[interval_length interval_units end_date]
+      expect(subscription_line_item.reload.slice(attrs).values).to eq [nil, nil, nil]
+    end
   end
 
   describe '.group' do


### PR DESCRIPTION
In this PR I'm going to implement the second solution proposed in the issue because I think that if those fields on the source have completed their goal and we don't need them anymore on the line items it is conceptually good to *move* them in the subscription. And it also seems to me the way less prone to unexpected side effects/bugs (keep it simple).

Closes #114.