### PR TITLE
Load factories using the new standard

### DIFF
--- a/lib/solidus_subscriptions/testing_support/factories.rb
+++ b/lib/solidus_subscriptions/testing_support/factories.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'factory_bot'
-require 'spree/testing_support/factories'
-
-factory_path = "#{File.dirname(__FILE__)}/factories/**/*_factory.rb"
-Dir[factory_path].each { |f| require File.expand_path(f) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,7 @@ require 'solidus_dev_support/rspec/feature_helper'
 # in spec/support/ and its subdirectories.
 Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
 
-# Requires factories defined in lib/solidus_subscriptions/factories.rb
-require 'solidus_subscriptions/testing_support/factories'
+SolidusDevSupport::TestingSupport::Factories.load_for(SolidusSubscriptions::Engine)
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
This will load factories using `FactoryBot.find_definitions` for Solidus versions that support it, otherwise it fallbacks on the old way (manually requiring factories).