### PR TITLE
Skip ActiveJob retrying for ProcessInstallmentJob

### DIFF
--- a/app/jobs/solidus_subscriptions/process_installment_job.rb
+++ b/app/jobs/solidus_subscriptions/process_installment_job.rb
@@ -6,6 +6,8 @@ module SolidusSubscriptions
 
     def perform(installment)
       Checkout.new(installment).process
+    rescue StandardError => e
+      SolidusSubscriptions.configuration.process_job_error_handler&.call(e)
     end
   end
 end

--- a/app/jobs/solidus_subscriptions/process_installment_job.rb
+++ b/app/jobs/solidus_subscriptions/process_installment_job.rb
@@ -7,7 +7,7 @@ module SolidusSubscriptions
     def perform(installment)
       Checkout.new(installment).process
     rescue StandardError => e
-      SolidusSubscriptions.configuration.process_job_error_handler&.call(e)
+      SolidusSubscriptions.configuration.processing_error_handler&.call(e)
     end
   end
 end

--- a/lib/generators/solidus_subscriptions/install/templates/initializer.rb
+++ b/lib/generators/solidus_subscriptions/install/templates/initializer.rb
@@ -26,6 +26,13 @@ SolidusSubscriptions.configure do |config|
   # failure cancel the subscription.
   # config.maximum_reprocessing_time = nil
 
+  # This custom error handler is called when a ProcessInstallmentJob `#perform` method fails.
+  # The rescued error can be managed as requried via a Proc, such as one which logs the error
+  # on an error tracking system.
+  # Though not recommended due to the retry mechanisms built into this gem, the error can be
+  # re-raised if the default retry behaviour is required in ActiveJob.
+  # config.process_job_error_handler = nil
+
   # ========================================= Dispatchers ==========================================
   #
   # These dispatchers are pluggable. If you override any handlers, it is highly encouraged that you

--- a/lib/generators/solidus_subscriptions/install/templates/initializer.rb
+++ b/lib/generators/solidus_subscriptions/install/templates/initializer.rb
@@ -27,11 +27,11 @@ SolidusSubscriptions.configure do |config|
   # config.maximum_reprocessing_time = nil
 
   # This custom error handler is called when a ProcessInstallmentJob `#perform` method fails.
-  # The rescued error can be managed as requried via a Proc, such as one which logs the error
+  # The rescued error can be managed as required via a Proc, such as one which logs the error
   # on an error tracking system.
   # Though not recommended due to the retry mechanisms built into this gem, the error can be
   # re-raised if the default retry behaviour is required in ActiveJob.
-  # config.process_job_error_handler = nil
+  # config.processing_error_handler = nil
 
   # ========================================= Dispatchers ==========================================
   #

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -4,14 +4,14 @@ module SolidusSubscriptions
   class Configuration
     attr_accessor(
       :maximum_total_skips, :maximum_reprocessing_time, :churn_buster_account_id,
-      :churn_buster_api_key, :clear_past_installments,
+      :churn_buster_api_key, :clear_past_installments, :processing_error_handler,
     )
 
     attr_writer(
       :success_dispatcher_class, :failure_dispatcher_class, :payment_failed_dispatcher_class,
       :out_of_stock_dispatcher, :maximum_successive_skips, :reprocessing_interval,
       :minimum_cancellation_notice, :processing_queue, :subscription_line_item_attributes,
-      :subscription_attributes, :subscribable_class, :process_job_error_handler,
+      :subscription_attributes, :subscribable_class,
     )
 
     def success_dispatcher_class
@@ -79,10 +79,6 @@ module SolidusSubscriptions
 
     def churn_buster?
       churn_buster_account_id.present? && churn_buster_api_key.present?
-    end
-
-    def process_job_error_handler
-      @process_job_error_handler ||= nil
     end
   end
 end

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -11,7 +11,7 @@ module SolidusSubscriptions
       :success_dispatcher_class, :failure_dispatcher_class, :payment_failed_dispatcher_class,
       :out_of_stock_dispatcher, :maximum_successive_skips, :reprocessing_interval,
       :minimum_cancellation_notice, :processing_queue, :subscription_line_item_attributes,
-      :subscription_attributes, :subscribable_class,
+      :subscription_attributes, :subscribable_class, :process_job_error_handler,
     )
 
     def success_dispatcher_class
@@ -79,6 +79,10 @@ module SolidusSubscriptions
 
     def churn_buster?
       churn_buster_account_id.present? && churn_buster_api_key.present?
+    end
+
+    def process_job_error_handler
+      @process_job_error_handler ||= nil
     end
   end
 end

--- a/spec/jobs/solidus_subscriptions/process_installment_job_spec.rb
+++ b/spec/jobs/solidus_subscriptions/process_installment_job_spec.rb
@@ -8,4 +8,16 @@ RSpec.describe SolidusSubscriptions::ProcessInstallmentJob do
 
     expect(checkout).to have_received(:process)
   end
+
+  context 'when handling #perform errors' do
+    it 'swallows error on #perfom error' do
+      expect { described_class.perform_now(nil) }.not_to raise_error(StandardError)
+    end
+
+    it 'runs proc on #perform error' do
+      stub_config(process_job_error_handler: proc { |e| raise e } )
+
+      expect { described_class.perform_now(nil) }.to raise_error(StandardError)
+    end
+  end
 end

--- a/spec/jobs/solidus_subscriptions/process_installment_job_spec.rb
+++ b/spec/jobs/solidus_subscriptions/process_installment_job_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe SolidusSubscriptions::ProcessInstallmentJob do
   end
 
   context 'when handling #perform errors' do
-    it 'swallows error on #perfom error' do
+    it 'swallows error when a proc is not configured' do
       expect { described_class.perform_now(nil) }.not_to raise_error(StandardError)
     end
 
-    it 'runs proc on #perform error' do
-      stub_config(process_job_error_handler: proc { |e| raise e } )
+    it 'runs proc when a proc is configured' do
+      stub_config(processing_error_handler: proc { |e| raise e } )
 
       expect { described_class.perform_now(nil) }.to raise_error(StandardError)
     end


### PR DESCRIPTION
Fixes https://github.com/solidusio-contrib/solidus_subscriptions/issues/175

This disables the ActiveJob default retry mechanism because installment
processing failures are already taken care of by solidus_subscriptions.

Before this, there was a potential for double retrying, which could
causes background jobs and canceled orders to accumulate leading
to side effects and a bad customer experience.

Now, a `process_job_error_handler` configuration Proc is called when a
ProcessInstallmentJob `#perfom` method fails.
The rescued error can be managed/logged as preferred or re-raised
if the default retry behavior is required in the ProcessInstallmentJob.