### PR TITLE
Set default config currency to subscription

### DIFF
--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -33,6 +33,7 @@ module SolidusSubscriptions
     accepts_nested_attributes_for :line_items, allow_destroy: true, reject_if: ->(p) { p[:quantity].blank? }
 
     before_validation :set_payment_method
+    before_validation :set_currency
     before_create :generate_guest_token
     after_create :emit_event_for_creation
     before_update :update_actionable_date_if_interval_changed
@@ -309,6 +310,10 @@ module SolidusSubscriptions
       if payment_source
         self.payment_method = payment_source.payment_method
       end
+    end
+
+    def set_currency
+      self.currency ||= ::Spree::Config[:currency]
     end
 
     def generate_guest_token

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
           orders: Orders
         new:
           back: Back to Subscriptions List
-          title: Create a Susbcription
+          title: Create a Subscription
         form:
           subscription: Subscription
           subscription_line_items: Line Items

--- a/spec/features/admin/subscriptions_spec.rb
+++ b/spec/features/admin/subscriptions_spec.rb
@@ -1,18 +1,61 @@
 RSpec.describe 'Subscriptions admin' do
   stub_authorization!
 
+  let(:shipping_address_fieldset) { 'Shipping Address' }
+  let(:billing_address_fieldset) { 'Billing Address' }
+
   it 'Updating a subscription' do
     subscription = create(:subscription, :with_shipping_address, :with_billing_address)
 
     visit spree.admin_path
     click_link 'Subscriptions'
     find('.fa-edit').click
-    fill_in 'subscription[shipping_address_attributes][zipcode]', with: '33166'
-    fill_in 'subscription[billing_address_attributes][zipcode]', with: '33167'
+    within_fieldset(shipping_address_fieldset) do
+      fill_in 'Zip Code', with: '33166'
+    end
+    within_fieldset(billing_address_fieldset) do
+      fill_in 'Zip Code', with: '33167'
+    end
     click_button 'Update'
     subscription.reload
 
     expect(subscription.shipping_address.zipcode).to eq('33166')
     expect(subscription.billing_address.zipcode).to eq('33167')
+  end
+
+  it 'Creates a subscription' do
+    variant = create(:variant, subscribable: true)
+    create(:user)
+    create(:store)
+
+    visit spree.admin_path
+    click_link 'Subscriptions'
+    click_link 'New Subscription'
+    fill_in 'Actionable date', with: '01/01/2020'
+    fill_in 'Interval length', with: 2
+    fill_in 'End date', with: '01/03/2020'
+
+    [shipping_address_fieldset, billing_address_fieldset].each do |fieldset|
+      within_fieldset(fieldset) do
+        name_input_label = if Spree.solidus_gem_version >= Gem::Version.new('2.11.0')
+                             'Name'
+                           else
+                             'First Name'
+                           end
+
+        fill_in name_input_label, with: 'John Doe'
+        fill_in 'Street Address', with: 'Street Address'
+        fill_in 'City', with: 'City'
+        fill_in 'Zip Code', with: '33166'
+        fill_in 'Phone', with: '1234567890'
+      end
+    end
+
+    select variant.name, from: 'Subscribable'
+    fill_in 'Quantity', with: 1
+
+    expect { click_on 'Create' }.to change { SolidusSubscriptions::Subscription.count }.by(1)
+
+    expect(page).to have_text('Subscription has been successfully created!')
   end
 end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
       expect(subscription.guest_token).to be_present
     end
+
+    it 'sets default config currency if not given' do
+      subscription = create(:subscription, currency: nil)
+
+      expect(subscription.currency).to eq(Spree::Config.currency)
+    end
   end
 
   describe 'updating a subscription' do


### PR DESCRIPTION
This fixes #207, setting the currency value to the default `Spree::Config` one.

It also adds a UI test for subscription creation from admin panel.