### PR TITLE
Remove variant from subscriptions on soft deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ SolidusSubscriptions.configure do |config|
 end
 ```
 
+### Subscription product deletion
+When a product is soft deleted, its subscription line items need to be deleted as well, in order to avoid error on subscription processing.
+If the product class is `Spree::Variant`, this corner case is handled automatically on the variant soft deletion, otherwise it should be handled manually.
+
 ## Development
 
 ### Testing the extension

--- a/app/decorators/models/solidus_subscriptions/spree/variant/auto_delete_from_subscriptions.rb
+++ b/app/decorators/models/solidus_subscriptions/spree/variant/auto_delete_from_subscriptions.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SolidusSubscriptions
+  module Spree
+    module Variant
+      module AutoDeleteFromSubscriptions
+        def self.prepended(base)
+          base.after_discard(:remove_from_subscriptions)
+          base.after_destroy(:remove_from_subscriptions)
+        end
+
+        def remove_from_subscriptions
+          SolidusSubscriptions::LineItem.where(subscribable: self).delete_all
+        end
+      end
+    end
+  end
+end
+
+Spree::Variant.prepend(SolidusSubscriptions::Spree::Variant::AutoDeleteFromSubscriptions)

--- a/spec/decorators/models/solidus_subscriptions/spree/variant/auto_delete_from_subscriptions_spec.rb
+++ b/spec/decorators/models/solidus_subscriptions/spree/variant/auto_delete_from_subscriptions_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe SolidusSubscriptions::Spree::Variant::AutoDeleteFromSubscriptions, type: :model do
+  subject { create(:variant, subscribable: true) }
+
+  describe '.discard' do
+    it 'deletes itself from subscriptions' do
+      subscription = create(:subscription)
+      create(:subscription_line_item, subscription: subscription, subscribable: subject)
+
+      expect { subject.discard }.to change { SolidusSubscriptions::LineItem.count }.by(-1)
+    end
+  end
+
+  describe '.destroy' do
+    it 'deletes itself from subscriptions' do
+      subscription = create(:subscription)
+      create(:subscription_line_item, subscription: subscription, subscribable: subject)
+
+      expect { subject.destroy }.to change { SolidusSubscriptions::LineItem.count }.by(-1)
+    end
+  end
+end


### PR DESCRIPTION
This should fix #133

In this PR, when a `Spree::Variant` is soft-deleted, its related subscription line items are deleted too.
If the product class is not a `Spree::Variant`, the variant subscription line items deletion should be handled manually.