### PR TITLE
Require a version of solidus_support that autoloads subscribers

### DIFF
--- a/solidus_subscriptions.gemspec
+++ b/solidus_subscriptions.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'httparty', '~> 0.18'
   spec.add_dependency 'i18n'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  spec.add_dependency 'solidus_support', '~> 0.5'
+  spec.add_dependency 'solidus_support', '~> 0.7'
   spec.add_dependency 'state_machines'
 
   spec.add_development_dependency 'rspec-activemodel-mocks'


### PR DESCRIPTION
This is required in Solidus v2.11+, otherwise the extensions' subscriber won't be loaded automatically.

Related https://github.com/solidusio-contrib/solidus_subscriptions/commit/5b1795151eb52ec8c5097f3ad58db055d9acb1bb.