### PR TITLE
Add missing permissions sets for Solidus v2.11

### DIFF
--- a/lib/solidus_subscriptions/permission_sets/default_customer.rb
+++ b/lib/solidus_subscriptions/permission_sets/default_customer.rb
@@ -4,12 +4,12 @@ module SolidusSubscriptions
   module PermissionSets
     class DefaultCustomer < ::Spree::PermissionSets::Base
       def activate!
-        can [:display, :update, :skip, :cancel], Subscription, ['user_id = ?', user.id] do |subscription, guest_token|
+        can [:show, :display, :update, :skip, :cancel], Subscription, ['user_id = ?', user.id] do |subscription, guest_token|
           (subscription.guest_token.present? && subscription.guest_token == guest_token) ||
             (subscription.user && subscription.user == user)
         end
 
-        can [:display, :update, :destroy], LineItem do |line_item, guest_token|
+        can [:show, :display, :update, :destroy], LineItem do |line_item, guest_token|
           (line_item.subscription&.guest_token.present? && line_item.subscription.guest_token == guest_token) ||
             (line_item.subscription&.user && line_item.subscription.user == user)
         end

--- a/spec/lib/solidus_subscriptions/permission_sets/default_customer_spec.rb
+++ b/spec/lib/solidus_subscriptions/permission_sets/default_customer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).to be_able_to([:display, :update], subscription)
+      expect(ability).to be_able_to([:show, :display, :update], subscription)
     end
 
     it "is not allowed to display or update someone else's subscriptions" do
@@ -21,7 +21,7 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).not_to be_able_to([:display, :update], subscription)
+      expect(ability).not_to be_able_to([:show, :display, :update], subscription)
     end
 
     it 'is allowed to display and update line items on their subscriptions' do
@@ -33,7 +33,7 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).to be_able_to([:display, :update], line_item)
+      expect(ability).to be_able_to([:show, :display, :update], line_item)
     end
 
     it "is not allowed to display or update line items on someone else's subscriptions" do
@@ -45,7 +45,7 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).not_to be_able_to([:display, :update], line_item)
+      expect(ability).not_to be_able_to([:show, :display, :update], line_item)
     end
   end
 
@@ -57,7 +57,7 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).to be_able_to([:display, :update], subscription, subscription.guest_token)
+      expect(ability).to be_able_to([:show, :display, :update], subscription, subscription.guest_token)
     end
 
     it "is not allowed to display or update someone else's subscriptions" do
@@ -67,7 +67,7 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).not_to be_able_to([:display, :update], subscription, 'invalid')
+      expect(ability).not_to be_able_to([:show, :display, :update], subscription, 'invalid')
     end
 
     it 'is allowed to display and update line items on their subscriptions' do
@@ -78,7 +78,7 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).to be_able_to([:display, :update], line_item, subscription.guest_token)
+      expect(ability).to be_able_to([:show, :display, :update], line_item, subscription.guest_token)
     end
 
     it "is not allowed to display or update line items on someone else's subscriptions" do
@@ -89,7 +89,7 @@ RSpec.describe SolidusSubscriptions::PermissionSets::DefaultCustomer do
       permission_set = described_class.new(ability)
       permission_set.activate!
 
-      expect(ability).not_to be_able_to([:display, :update], line_item, 'invalid')
+      expect(ability).not_to be_able_to([:show, :display, :update], line_item, 'invalid')
     end
   end
 end


### PR DESCRIPTION
Although an effort to grant a seamless transition has been done, this change is still necessary because of the many places in which `can? :display` has become `can? :show` or `can? :read`.

Ref: https://github.com/solidusio/solidus/pull/3701