### PR TITLE
Reload order during finalize action

### DIFF
--- a/app/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions.rb
+++ b/app/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions.rb
@@ -13,6 +13,8 @@ module SolidusSubscriptions
             SolidusSubscriptions::SubscriptionGenerator.activate(line_items)
           end
 
+          reload
+
           super
         end
       end

--- a/spec/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions_spec.rb
+++ b/spec/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SolidusSubscriptions::Spree::Order::FinalizeCreatesSubscriptions 
 
     let(:order) { create :order, :with_subscription_line_items }
     let(:subscription_line_item) { order.subscription_line_items.last }
-    let(:expected_actionable_date) { Time.zone.today + subscription_line_item.interval }
+    let(:expected_actionable_date) { Time.zone.today + subscription_line_item.subscription.interval }
 
     around { |e| Timecop.freeze { e.run } }
 


### PR DESCRIPTION
If you decorate the subscription generator to change the order
in any way (for instance, to associate the order to the
subscription), that change is not persisted in the rest of the
finalize action, as the order has already been loaded by that
point.

This can cause massive headaches with validations, so to fix it
I've added a reload method before super, so we can ensure that
the order is up-to-date before continuing.

This also means that subscription_line_items interval is nil,
since activating the subscription sets it to nil. So in the spec
we're fetching the interval from the subscription instead.