### PR TITLE
Fix Api Subscription Permitted LineItem Attributes

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -78,7 +78,7 @@ module SolidusSubscriptions
         end
 
         def line_item_attributes
-          SolidusSubscriptions.configuration.subscription_line_item_attributes - [:subscribable_id] + [:id]
+          SolidusSubscriptions.configuration.subscription_line_item_attributes
         end
 
         def update_payment_attributes(attributes)

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -52,6 +52,7 @@ module SolidusSubscriptions
 
     def subscription_line_item_attributes
       @subscription_line_item_attributes ||= [
+        :id,
         :quantity,
         :subscribable_id,
         :interval_length,


### PR DESCRIPTION
This removes a filter on the api `SubscriptionsController `that made it impossible to add a subscribable_id to the nested line_item_attributes (effectively prohibiting the creation of LineItems on the creation of a Subscription.

This allows the api to be more flexible but still allows users to limit certain operations by customizing the `config.subscription_line_item_attributes`