### PR TITLE
Introduce Installment OrderCreator configuration

### DIFF
--- a/lib/generators/solidus_subscriptions/install/templates/initializer.rb
+++ b/lib/generators/solidus_subscriptions/install/templates/initializer.rb
@@ -96,4 +96,18 @@ SolidusSubscriptions.configure do |config|
   # with new subscription cycles by clearing any past failed installment when a new one is created
 
   # config.clear_past_installments = true
+
+  # ==================================== Custom Order Creation =====================================
+  #
+  # This settings allows the customization of the creation of each Installment Order and / or
+  # adding additional attributes to the Order
+  #
+  # config.order_creation_class = 'SolidusSubscriptions::OrderCreator'
+  #
+  # this class is initialized and called on the creation of the Order for each Subscription Installment
+  # along with a customizable hash of extra attributes that can also be configured, like below:
+  # config.order_creation_extra_attributes = { channel: 'subscriptions' }
+  #
+  #
+  # config.order_creation_extra_attributes = { }
 end

--- a/lib/generators/solidus_subscriptions/install/templates/initializer.rb
+++ b/lib/generators/solidus_subscriptions/install/templates/initializer.rb
@@ -99,15 +99,14 @@ SolidusSubscriptions.configure do |config|
 
   # ==================================== Custom Order Creation =====================================
   #
-  # This settings allows the customization of the creation of each Installment Order and / or
-  # adding additional attributes to the Order
-  #
-  # config.order_creation_class = 'SolidusSubscriptions::OrderCreator'
-  #
-  # this class is initialized and called on the creation of the Order for each Subscription Installment
-  # along with a customizable hash of extra attributes that can also be configured, like below:
-  # config.order_creation_extra_attributes = { channel: 'subscriptions' }
+  # This settings allows the customization of the creation of each Installment Order by means of
+  # providing a class that can be switched / inherited
   #
   #
-  # config.order_creation_extra_attributes = { }
+  # the order_creator_class is initialized and called on the creation of the Order for each Subscription
+  # Installment.
+  # If you want to add simple extra attributes to the Order (such as a channel), that can be done by
+  # overriding the `extra_attributes` method on a subclass
+  #
+  # config.order_creator_class = 'SolidusSubscriptions::OrderCreator'
 end

--- a/lib/solidus_subscriptions.rb
+++ b/lib/solidus_subscriptions.rb
@@ -26,6 +26,7 @@ require 'solidus_subscriptions/dispatcher/failure_dispatcher'
 require 'solidus_subscriptions/dispatcher/out_of_stock_dispatcher'
 require 'solidus_subscriptions/dispatcher/payment_failed_dispatcher'
 require 'solidus_subscriptions/dispatcher/success_dispatcher'
+require 'solidus_subscriptions/order_creator'
 
 module SolidusSubscriptions
   class << self

--- a/lib/solidus_subscriptions/checkout.rb
+++ b/lib/solidus_subscriptions/checkout.rb
@@ -32,14 +32,8 @@ module SolidusSubscriptions
     private
 
     def create_order
-      ::Spree::Order.create(
-        user: installment.subscription.user,
-        email: installment.subscription.user.email,
-        store: installment.subscription.store || ::Spree::Store.default,
-        subscription_order: true,
-        subscription: installment.subscription,
-        currency: installment.subscription.currency
-      )
+      extra_attributes = SolidusSubscriptions.configuration.order_creation_extra_attributes
+      SolidusSubscriptions.configuration.order_creation_class.new(installment, extra_attributes).call
     end
 
     def populate_order(order)
@@ -61,7 +55,7 @@ module SolidusSubscriptions
           order.payments.create(
             payment_method: installment.subscription.payment_method_to_use,
             source: installment.subscription.payment_source_to_use,
-            amount: order.total,
+            amount: order.total
           )
         end
 

--- a/lib/solidus_subscriptions/checkout.rb
+++ b/lib/solidus_subscriptions/checkout.rb
@@ -32,8 +32,7 @@ module SolidusSubscriptions
     private
 
     def create_order
-      extra_attributes = SolidusSubscriptions.configuration.order_creation_extra_attributes
-      SolidusSubscriptions.configuration.order_creation_class.new(installment, extra_attributes).call
+      SolidusSubscriptions.configuration.order_creator_class.new(installment).call
     end
 
     def populate_order(order)

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -4,14 +4,14 @@ module SolidusSubscriptions
   class Configuration
     attr_accessor(
       :maximum_total_skips, :maximum_reprocessing_time, :churn_buster_account_id,
-      :churn_buster_api_key, :clear_past_installments, :processing_error_handler,
+      :churn_buster_api_key, :clear_past_installments, :processing_error_handler, :order_creation_extra_attributes
     )
 
     attr_writer(
       :success_dispatcher_class, :failure_dispatcher_class, :payment_failed_dispatcher_class,
       :out_of_stock_dispatcher, :maximum_successive_skips, :reprocessing_interval,
       :minimum_cancellation_notice, :processing_queue, :subscription_line_item_attributes,
-      :subscription_attributes, :subscribable_class,
+      :subscription_attributes, :subscribable_class, :order_creation_class
     )
 
     def success_dispatcher_class
@@ -57,7 +57,7 @@ module SolidusSubscriptions
         :subscribable_id,
         :interval_length,
         :interval_units,
-        :end_date,
+        :end_date
       ]
     end
 
@@ -69,7 +69,7 @@ module SolidusSubscriptions
         {
           shipping_address_attributes: Spree::PermittedAttributes.address_attributes,
           billing_address_attributes: Spree::PermittedAttributes.address_attributes
-        },
+        }
       ]
     end
 
@@ -80,6 +80,11 @@ module SolidusSubscriptions
 
     def churn_buster?
       churn_buster_account_id.present? && churn_buster_api_key.present?
+    end
+
+    def order_creation_class
+      @order_creation_class ||= 'SolidusSubscriptions::OrderCreator'
+      @order_creation_class.constantize
     end
   end
 end

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -4,14 +4,14 @@ module SolidusSubscriptions
   class Configuration
     attr_accessor(
       :maximum_total_skips, :maximum_reprocessing_time, :churn_buster_account_id,
-      :churn_buster_api_key, :clear_past_installments, :processing_error_handler, :order_creation_extra_attributes
+      :churn_buster_api_key, :clear_past_installments, :processing_error_handler
     )
 
     attr_writer(
       :success_dispatcher_class, :failure_dispatcher_class, :payment_failed_dispatcher_class,
       :out_of_stock_dispatcher, :maximum_successive_skips, :reprocessing_interval,
       :minimum_cancellation_notice, :processing_queue, :subscription_line_item_attributes,
-      :subscription_attributes, :subscribable_class, :order_creation_class
+      :subscription_attributes, :subscribable_class, :order_creator_class
     )
 
     def success_dispatcher_class
@@ -82,9 +82,9 @@ module SolidusSubscriptions
       churn_buster_account_id.present? && churn_buster_api_key.present?
     end
 
-    def order_creation_class
-      @order_creation_class ||= 'SolidusSubscriptions::OrderCreator'
-      @order_creation_class.constantize
+    def order_creator_class
+      @order_creator_class ||= 'SolidusSubscriptions::OrderCreator'
+      @order_creator_class.constantize
     end
   end
 end

--- a/lib/solidus_subscriptions/order_creator.rb
+++ b/lib/solidus_subscriptions/order_creator.rb
@@ -18,7 +18,7 @@ module SolidusSubscriptions
       )
     end
 
-    protected
+    private
 
     def extra_attributes
       {}

--- a/lib/solidus_subscriptions/order_creator.rb
+++ b/lib/solidus_subscriptions/order_creator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module SolidusSubscriptions
+  class OrderCreator
+    def initialize(installment, extra_attributes)
+      @installment = installment
+      @extra_attributes = (extra_attributes || {}).symbolize_keys
+    end
+
+    def call
+      ::Spree::Order.create(
+        user: installment.subscription.user,
+        email: installment.subscription.user.email,
+        store: installment.subscription.store || ::Spree::Store.default,
+        subscription_order: true,
+        subscription: installment.subscription,
+        currency: installment.subscription.currency,
+        **extra_attributes
+      )
+    end
+
+    protected
+
+    attr_reader :installment, :extra_attributes
+  end
+end

--- a/lib/solidus_subscriptions/order_creator.rb
+++ b/lib/solidus_subscriptions/order_creator.rb
@@ -2,9 +2,8 @@
 
 module SolidusSubscriptions
   class OrderCreator
-    def initialize(installment, extra_attributes)
+    def initialize(installment)
       @installment = installment
-      @extra_attributes = (extra_attributes || {}).symbolize_keys
     end
 
     def call
@@ -21,6 +20,10 @@ module SolidusSubscriptions
 
     protected
 
-    attr_reader :installment, :extra_attributes
+    def extra_attributes
+      {}
+    end
+
+    attr_reader :installment
   end
 end


### PR DESCRIPTION
This adds both `SolidusSubscriptions.configuration.order_creation_class` and `SolidusSubscriptions.configuration.order_creation_extra attributes`, so that users can add attributes to each Installment Order at Checkout or even override how the Order is created.