### PR TITLE
Log installments errors by default

### DIFF
--- a/app/jobs/solidus_subscriptions/process_installment_job.rb
+++ b/app/jobs/solidus_subscriptions/process_installment_job.rb
@@ -7,7 +7,7 @@ module SolidusSubscriptions
     def perform(installment)
       Checkout.new(installment).process
     rescue StandardError => e
-      SolidusSubscriptions.configuration.processing_error_handler&.call(e)
+      SolidusSubscriptions.configuration.processing_error_handler&.call(e, installment)
     end
   end
 end

--- a/lib/generators/solidus_subscriptions/install/templates/initializer.rb
+++ b/lib/generators/solidus_subscriptions/install/templates/initializer.rb
@@ -31,7 +31,9 @@ SolidusSubscriptions.configure do |config|
   # on an error tracking system.
   # Though not recommended due to the retry mechanisms built into this gem, the error can be
   # re-raised if the default retry behaviour is required in ActiveJob.
-  # config.processing_error_handler = nil
+  #
+  # By default, it only logs the error message using Rails.logger.error.
+  # config.processing_error_handler = SolidusSubscriptions::ProcessingErrorHandlers::RailsLogger
 
   # ========================================= Dispatchers ==========================================
   #

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -4,14 +4,14 @@ module SolidusSubscriptions
   class Configuration
     attr_accessor(
       :maximum_total_skips, :maximum_reprocessing_time, :churn_buster_account_id,
-      :churn_buster_api_key, :clear_past_installments, :processing_error_handler
+      :churn_buster_api_key, :clear_past_installments
     )
 
     attr_writer(
       :success_dispatcher_class, :failure_dispatcher_class, :payment_failed_dispatcher_class,
       :out_of_stock_dispatcher, :maximum_successive_skips, :reprocessing_interval,
       :minimum_cancellation_notice, :processing_queue, :subscription_line_item_attributes,
-      :subscription_attributes, :subscribable_class, :order_creator_class
+      :subscription_attributes, :subscribable_class, :order_creator_class, :processing_error_handler
     )
 
     def success_dispatcher_class
@@ -32,6 +32,11 @@ module SolidusSubscriptions
     def out_of_stock_dispatcher_class
       @out_of_stock_dispatcher_class ||= 'SolidusSubscriptions::Dispatcher::OutOfStockDispatcher'
       @out_of_stock_dispatcher_class.constantize
+    end
+
+    def processing_error_handler
+      @processing_error_handler ||= 'SolidusSubscriptions::ProcessingErrorHandlers::RailsLogger'
+      @processing_error_handler.constantize
     end
 
     def maximum_successive_skips

--- a/lib/solidus_subscriptions/engine.rb
+++ b/lib/solidus_subscriptions/engine.rb
@@ -6,6 +6,7 @@ require 'solidus_subscriptions'
 require 'solidus_subscriptions/permitted_attributes'
 require 'solidus_subscriptions/configuration'
 require 'solidus_subscriptions/processor'
+require 'solidus_subscriptions/processing_error_handlers/rails_logger'
 
 module SolidusSubscriptions
   class Engine < Rails::Engine

--- a/lib/solidus_subscriptions/processing_error_handlers/rails_logger.rb
+++ b/lib/solidus_subscriptions/processing_error_handlers/rails_logger.rb
@@ -3,21 +3,23 @@
 module SolidusSubscriptions
   module ProcessingErrorHandlers
     class RailsLogger
-      def self.call(exception)
-        new(exception).call
+      def self.call(exception, installment = nil)
+        new(exception, installment).call
       end
 
-      def initialize(exception)
+      def initialize(exception, installment = nil)
         @exception = exception
+        @installment = installment
       end
 
       def call
-        Rails.logger.error exception.message
+        Rails.logger.error("Error processing installment with ID=#{installment.id}:") if installment
+        Rails.logger.error(exception.message)
       end
 
       private
 
-      attr_reader :exception
+      attr_reader :exception, :installment
     end
   end
 end

--- a/lib/solidus_subscriptions/processing_error_handlers/rails_logger.rb
+++ b/lib/solidus_subscriptions/processing_error_handlers/rails_logger.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module SolidusSubscriptions
+  module ProcessingErrorHandlers
+    class RailsLogger
+      def self.call(exception)
+        new(exception).call
+      end
+
+      def initialize(exception)
+        @exception = exception
+      end
+
+      def call
+        Rails.logger.error exception.message
+      end
+
+      private
+
+      attr_reader :exception
+    end
+  end
+end

--- a/spec/jobs/solidus_subscriptions/process_installment_job_spec.rb
+++ b/spec/jobs/solidus_subscriptions/process_installment_job_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe SolidusSubscriptions::ProcessInstallmentJob do
   end
 
   context 'when handling #perform errors' do
-    it 'by default logs exception data without raising exceptions' do
+    it 'by default logs exception data without raising exceptions' do # rubocop:disable RSpec/MultipleExpectations
+      installment = build_stubbed(:installment)
       checkout = instance_double(SolidusSubscriptions::Checkout).tap do |c|
         allow(c).to receive(:process).and_raise('test error')
       end
@@ -20,9 +21,10 @@ RSpec.describe SolidusSubscriptions::ProcessInstallmentJob do
       allow(Rails.logger).to receive(:error)
 
       expect {
-        described_class.perform_now(build_stubbed(:installment))
+        described_class.perform_now(installment)
       }.not_to raise_error
 
+      expect(Rails.logger).to have_received(:error).with("Error processing installment with ID=#{installment.id}:").ordered
       expect(Rails.logger).to have_received(:error).with("test error").ordered
     end
 


### PR DESCRIPTION
At the moment, by default, all installment processing errors are swallowed and there's no way for a developer to understand what's happening. Of course, they can create a custom handler with the `processing_error_handler` configuration provided but usually, when the first errors happen, it's too late and those errors are lost.

We are not raising errors of this job because if there's a retry mechanism in place for Active Job, the installment will be reprocessed twice. Once by Active Job and once by the installment retry mechanism already provided by the extension.

Logging to `Rails.error` is a middle-ground that allows to intercept the message of the exception. Still, creating a custom handler based on the bug tracker/exception handler used is the suggested option here.

This PR also changes the signature of the handler call method (or proc) to allow passing the installment along with the exception.