### PR TITLE
Draft: Add ability to pause/resume subscriptions

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -56,6 +56,26 @@ module SolidusSubscriptions
           end
         end
 
+        def pause
+          load_subscription
+
+          if @subscription.pause(actionable_date: actionable_date_param)
+            render json: @subscription.to_json
+          else
+            render json: @subscription.errors.to_json, status: :unprocessable_entity
+          end
+        end
+
+        def resume
+          load_subscription
+
+          if @subscription.pause(actionable_date: actionable_date_param)
+            render json: @subscription.to_json
+          else
+            render json: @subscription.errors.to_json, status: :unprocessable_entity
+          end
+        end
+
         private
 
         def load_subscription
@@ -75,6 +95,10 @@ module SolidusSubscriptions
           params.require(:subscription).permit(SolidusSubscriptions.configuration.subscription_attributes | [
             line_items_attributes: line_item_attributes,
           ])
+        end
+
+        def actionable_date_param
+          params[:subscription].try(:[], :actionable_date)&.presence
         end
 
         def line_item_attributes

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -80,6 +80,30 @@ module Spree
         redirect_back(fallback_location: spree.admin_subscriptions_path, notice: notice)
       end
 
+      def pause
+        @subscription.pause(actionable_date: nil)
+
+        notice = if @subscription.errors.none?
+                   I18n.t('spree.admin.subscriptions.successfully_paused')
+                 else
+                   @subscription.errors.full_messages.to_sentence
+                 end
+
+        redirect_back(fallback_location: spree.admin_subscriptions_path, notice: notice)
+      end
+
+      def resume
+        @subscription.resume(actionable_date: nil)
+
+        notice = if @subscription.errors.none?
+                   I18n.t('spree.admin.subscriptions.successfully_resumed')
+                 else
+                   @subscription.errors.full_messages.to_sentence
+                 end
+
+        redirect_back(fallback_location: spree.admin_subscriptions_path, notice: notice)
+      end
+
       private
 
       def model_class

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -68,10 +68,14 @@ module Spree
       def skip
         @subscription.skip(check_skip_limits: false)
 
-        notice = I18n.t(
-          'spree.admin.subscriptions.successfully_skipped',
-          date: @subscription.actionable_date
-        )
+        notice = if @subscription.errors.none?
+                   I18n.t(
+                     'spree.admin.subscriptions.successfully_skipped',
+                     date: @subscription.actionable_date
+                   )
+                 else
+                   @subscription.errors.full_messages.to_sentence
+                 end
 
         redirect_back(fallback_location: spree.admin_subscriptions_path, notice: notice)
       end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -159,12 +159,14 @@ module SolidusSubscriptions
     end
 
     def skip(check_skip_limits: true)
+      check_incorrect_skip_states
+
       if check_skip_limits
         check_successive_skips_exceeded
         check_total_skips_exceeded
-
-        return if errors.any?
       end
+
+      return if errors.any?
 
       increment(:skip_count)
       increment(:successive_skip_count)
@@ -300,6 +302,9 @@ module SolidusSubscriptions
       end
     end
 
+    def check_incorrect_skip_states
+      errors.add(:state, :cannot_skip) if canceled? || inactive?
+    end
     def update_actionable_date_if_interval_changed
       if persisted? && (interval_length_previously_changed? || interval_units_previously_changed?)
         base_date = if installments.any?

--- a/app/views/spree/admin/shared/_subscription_actions.html.erb
+++ b/app/views/spree/admin/shared/_subscription_actions.html.erb
@@ -23,13 +23,32 @@
   <% end %>
 
   <% if subscription.active? %>
-    <%=
-      link_to(
-          t('spree.admin.subscriptions.actions.skip'),
-          spree.skip_admin_subscription_path(subscription),
-          method: :post,
-          class: 'btn btn-default',
-      )
-    %>
+    <% if subscription.paused? %>
+      <%=
+        link_to(
+            t('spree.admin.subscriptions.actions.resume'),
+            spree.resume_admin_subscription_path(subscription),
+            method: :post,
+            class: 'btn btn-default',
+        )
+      %>
+    <% else %>
+      <%=
+        link_to(
+            t('spree.admin.subscriptions.actions.pause'),
+            spree.pause_admin_subscription_path(subscription),
+            method: :post,
+            class: 'btn btn-default',
+        )
+      %>
+      <%=
+        link_to(
+            t('spree.admin.subscriptions.actions.skip'),
+            spree.skip_admin_subscription_path(subscription),
+            method: :post,
+            class: 'btn btn-default',
+        )
+      %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/spree/admin/subscriptions/_state_pill.html.erb
+++ b/app/views/spree/admin/subscriptions/_state_pill.html.erb
@@ -3,8 +3,9 @@
     canceled: 'error',
     pending_cancellation: 'warning',
     inactive: 'inactive',
-}[subscription.state.to_sym] %>
+    paused: 'pending'
+}[subscription.state_with_pause.to_sym] %>
 
 <span class="pill pill-<%= state_class %>">
-  <%= subscription.human_state_name %>
+  <%= subscription.state_with_pause.humanize %>
 </span>

--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -150,15 +150,36 @@
             <% end %>
 
             <% if subscription.active? %>
-              <%=
-                link_to_with_icon(
-                    :'fast-forward',
-                    t('spree.admin.subscriptions.actions.skip'),
-                    spree.skip_admin_subscription_path(subscription),
-                    no_text: true,
-                    method: :post
-                )
-              %>
+              <% if subscription.paused? %>
+                <%=
+                  link_to_with_icon(
+                      :'play-circle',
+                      t('spree.admin.subscriptions.actions.resume'),
+                      spree.resume_admin_subscription_path(subscription),
+                      no_text: true,
+                      method: :post
+                  )
+                %>
+              <% else %>
+                <%=
+                  link_to_with_icon(
+                      :'pause-circle',
+                      t('spree.admin.subscriptions.actions.pause'),
+                      spree.pause_admin_subscription_path(subscription),
+                      no_text: true,
+                      method: :post
+                  )
+                %>
+                <%=
+                  link_to_with_icon(
+                      :'fast-forward',
+                      t('spree.admin.subscriptions.actions.skip'),
+                      spree.skip_admin_subscription_path(subscription),
+                      no_text: true,
+                      method: :post
+                  )
+                %>
+              <% end %>
             <% end %>
 
             <%= link_to_edit(subscription, no_text: true) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,3 +127,5 @@ en:
               inclusion: "is not a valid currency code"
             payment_source:
               not_owned_by_user: "does not belong to the user associated with the subscription"
+            state:
+              cannot_skip: cannot skip a subscription which is canceled or inactive

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,11 +24,15 @@ en:
         successfully_canceled: Subscription Canceled!
         successfully_activated: Subscription Activated!
         successfully_skipped: Subscription delayed until %{date}
+        successfully_paused: Successfully Paused
+        successfully_resumed: Succesfully Resumed
         actions:
           cancel: Cancel
           cancel_alert: "Are you sure you want to cancel this subscription?"
           activate: Activate
           skip: Skip One
+          pause: Pause
+          resume: Resume
         index:
           new_subscription: New Subscription
         edit:
@@ -127,5 +131,8 @@ en:
               inclusion: "is not a valid currency code"
             payment_source:
               not_owned_by_user: "does not belong to the user associated with the subscription"
+            paused:
+              cannot_skip: "cannot skip a subscription which is paused"
+              not_active: "cannot pause/resume a subscription which is not active"
             state:
               cannot_skip: cannot skip a subscription which is canceled or inactive

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,9 +19,13 @@ Spree::Core::Engine.routes.draw do
 
   namespace :admin do
     resources :subscriptions, only: [:index, :new, :create, :edit, :update] do
-      delete :cancel, on: :member
-      post :activate, on: :member
-      post :skip, on: :member
+      member do
+        delete :cancel
+        post :activate
+        post :skip
+        post :pause
+        post :resume
+      end
       resources :installments, only: [:index, :show]
       resources :subscription_events, only: :index
       resources :subscription_orders, path: :orders, only: :index

--- a/db/migrate/20210905145955_add_paused_to_subscriptions.rb
+++ b/db/migrate/20210905145955_add_paused_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddPausedToSubscriptions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :solidus_subscriptions_subscriptions, :paused, :boolean, default: false
+  end
+end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -155,6 +155,8 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
     end
   end
 
+  # TODO: Migrate model specs here
+
   describe '#skip' do
     subject { subscription.skip&.to_date }
 

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -163,6 +163,8 @@ RSpec.describe '/api/v1/subscriptions' do
     end
   end
 
+  # TODO: Migrate API specs here
+
   describe 'POST /:id/skip' do
     context 'when the subscription belongs to the user' do
       it 'responds with 200 OK' do


### PR DESCRIPTION
This feature is mostly extracted from a client's project.
I hope to hear your thoughts on whether this would be a good fit for this gem.

The approach does not create a new state but views the `paused` "state" as a subset of the `active` state while manipulating the `actionable_date`.

Paused subscriptions will not be processed until a manual `#resume`
or the `actionable_date` is reached. If the `actionable_date` is not
set, the subscription will be `paused` indefinitely.

If, and when, the `actionable_date` is reached, the `pause` column
for will be set to `false` in
`#advance actionable_date`.

Also, for the robustness of the API, the "next day" is a minimum date that can be set for the `actionable_date` on resuming or pausing the subscription.

The first two commits include refactoring and improvements for the `#skip` event (which might be better in a separate PR). 

TODO: 
- [ ] Migrate specs over if the approach is useful over here.