### PR TITLE
Add ability to pause/resume subscriptions

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/subscriptions_controller.rb
@@ -56,6 +56,26 @@ module SolidusSubscriptions
           end
         end
 
+        def pause
+          load_subscription
+
+          if @subscription.pause(actionable_date: actionable_date_param)
+            render json: @subscription.to_json
+          else
+            render json: @subscription.errors.to_json, status: :unprocessable_entity
+          end
+        end
+
+        def resume
+          load_subscription
+
+          if @subscription.resume(actionable_date: actionable_date_param)
+            render json: @subscription.to_json
+          else
+            render json: @subscription.errors.to_json, status: :unprocessable_entity
+          end
+        end
+
         private
 
         def load_subscription
@@ -75,6 +95,10 @@ module SolidusSubscriptions
           params.require(:subscription).permit(SolidusSubscriptions.configuration.subscription_attributes | [
             line_items_attributes: line_item_attributes,
           ])
+        end
+
+        def actionable_date_param
+          params[:subscription].try(:[], :actionable_date)&.presence
         end
 
         def line_item_attributes

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -80,6 +80,30 @@ module Spree
         redirect_back(fallback_location: spree.admin_subscriptions_path, notice: notice)
       end
 
+      def pause
+        @subscription.pause(actionable_date: nil)
+
+        notice = if @subscription.errors.none?
+                   I18n.t('spree.admin.subscriptions.successfully_paused')
+                 else
+                   @subscription.errors.full_messages.to_sentence
+                 end
+
+        redirect_back(fallback_location: spree.admin_subscriptions_path, notice: notice)
+      end
+
+      def resume
+        @subscription.resume(actionable_date: nil)
+
+        notice = if @subscription.errors.none?
+                   I18n.t('spree.admin.subscriptions.successfully_resumed')
+                 else
+                   @subscription.errors.full_messages.to_sentence
+                 end
+
+        redirect_back(fallback_location: spree.admin_subscriptions_path, notice: notice)
+      end
+
       private
 
       def model_class

--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -68,10 +68,14 @@ module Spree
       def skip
         @subscription.skip(check_skip_limits: false)
 
-        notice = I18n.t(
-          'spree.admin.subscriptions.successfully_skipped',
-          date: @subscription.actionable_date
-        )
+        notice = if @subscription.errors.none?
+                   I18n.t(
+                     'spree.admin.subscriptions.successfully_skipped',
+                     date: @subscription.actionable_date
+                   )
+                 else
+                   @subscription.errors.full_messages.to_sentence
+                 end
 
         redirect_back(fallback_location: spree.admin_subscriptions_path, notice: notice)
       end

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -159,12 +159,14 @@ module SolidusSubscriptions
     end
 
     def skip(check_skip_limits: true)
+      check_invalid_skip_states
+
       if check_skip_limits
         check_successive_skips_exceeded
         check_total_skips_exceeded
-
-        return if errors.any?
       end
+
+      return if errors.any?
 
       increment(:skip_count)
       increment(:successive_skip_count)
@@ -298,6 +300,10 @@ module SolidusSubscriptions
       if skip_count >= SolidusSubscriptions.configuration.maximum_total_skips
         errors.add(:skip_count, :exceeded)
       end
+    end
+
+    def check_invalid_skip_states
+      errors.add(:state, :cannot_skip) if canceled? || inactive?
     end
 
     def update_actionable_date_if_interval_changed

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -171,7 +171,7 @@ module SolidusSubscriptions
       save!
 
       advance_actionable_date.tap do
-        events.create!(event_type: 'subscription_skipped')
+        create_and_emit_event(type: 'subscription_skipped')
       end
     end
 
@@ -338,11 +338,20 @@ module SolidusSubscriptions
       end
     end
 
-    def emit_event_for_creation
+    def emit_event(type:)
       ::Spree::Event.fire(
-        'solidus_subscriptions.subscription_created',
+        "solidus_subscriptions.#{type}",
         subscription: self,
       )
+    end
+
+    def create_and_emit_event(type:)
+      events.create!(event_type: type)
+      emit_event(type: type)
+    end
+
+    def emit_event_for_creation
+      emit_event(type: 'subscription_created')
     end
 
     def emit_event_for_transition
@@ -353,39 +362,24 @@ module SolidusSubscriptions
         inactive: 'subscription_ended',
       }[state.to_sym]
 
-      ::Spree::Event.fire(
-        "solidus_subscriptions.#{event_type}",
-        subscription: self,
-      )
+      emit_event(type: event_type)
     end
 
     def emit_events_for_update
       if previous_changes.key?('interval_length') || previous_changes.key?('interval_units')
-        ::Spree::Event.fire(
-          'solidus_subscriptions.subscription_frequency_changed',
-          subscription: self,
-        )
+        emit_event(type: 'subscription_frequency_changed')
       end
 
       if previous_changes.key?('shipping_address_id')
-        ::Spree::Event.fire(
-          'solidus_subscriptions.subscription_shipping_address_changed',
-          subscription: self,
-        )
+        emit_event(type: 'subscription_shipping_address_changed')
       end
 
       if previous_changes.key?('billing_address_id')
-        ::Spree::Event.fire(
-          'solidus_subscriptions.subscription_billing_address_changed',
-          subscription: self,
-        )
+        emit_event(type: 'subscription_billing_address_changed')
       end
 
       if previous_changes.key?('payment_source_id') || previous_changes.key?('payment_source_type') || previous_changes.key?('payment_method_id')
-        ::Spree::Event.fire(
-          'solidus_subscriptions.subscription_payment_method_changed',
-          subscription: self,
-        )
+        emit_event(type: 'subscription_payment_method_changed')
       end
     end
   end

--- a/app/views/spree/admin/shared/_subscription_actions.html.erb
+++ b/app/views/spree/admin/shared/_subscription_actions.html.erb
@@ -23,13 +23,32 @@
   <% end %>
 
   <% if subscription.active? %>
-    <%=
-      link_to(
-          t('spree.admin.subscriptions.actions.skip'),
-          spree.skip_admin_subscription_path(subscription),
-          method: :post,
-          class: 'btn btn-default',
-      )
-    %>
+    <% if subscription.paused? %>
+      <%=
+        link_to(
+            t('spree.admin.subscriptions.actions.resume'),
+            spree.resume_admin_subscription_path(subscription),
+            method: :post,
+            class: 'btn btn-default',
+        )
+      %>
+    <% else %>
+      <%=
+        link_to(
+            t('spree.admin.subscriptions.actions.pause'),
+            spree.pause_admin_subscription_path(subscription),
+            method: :post,
+            class: 'btn btn-default',
+        )
+      %>
+      <%=
+        link_to(
+            t('spree.admin.subscriptions.actions.skip'),
+            spree.skip_admin_subscription_path(subscription),
+            method: :post,
+            class: 'btn btn-default',
+        )
+      %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/spree/admin/subscriptions/_state_pill.html.erb
+++ b/app/views/spree/admin/subscriptions/_state_pill.html.erb
@@ -3,8 +3,9 @@
     canceled: 'error',
     pending_cancellation: 'warning',
     inactive: 'inactive',
-}[subscription.state.to_sym] %>
+    paused: 'pending'
+}[subscription.state_with_pause.to_sym] %>
 
 <span class="pill pill-<%= state_class %>">
-  <%= subscription.human_state_name %>
+  <%= subscription.state_with_pause.humanize %>
 </span>

--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -150,15 +150,36 @@
             <% end %>
 
             <% if subscription.active? %>
-              <%=
-                link_to_with_icon(
-                    :'fast-forward',
-                    t('spree.admin.subscriptions.actions.skip'),
-                    spree.skip_admin_subscription_path(subscription),
-                    no_text: true,
-                    method: :post
-                )
-              %>
+              <% if subscription.paused? %>
+                <%=
+                  link_to_with_icon(
+                      :'play-circle',
+                      t('spree.admin.subscriptions.actions.resume'),
+                      spree.resume_admin_subscription_path(subscription),
+                      no_text: true,
+                      method: :post
+                  )
+                %>
+              <% else %>
+                <%=
+                  link_to_with_icon(
+                      :'pause-circle',
+                      t('spree.admin.subscriptions.actions.pause'),
+                      spree.pause_admin_subscription_path(subscription),
+                      no_text: true,
+                      method: :post
+                  )
+                %>
+                <%=
+                  link_to_with_icon(
+                      :'fast-forward',
+                      t('spree.admin.subscriptions.actions.skip'),
+                      spree.skip_admin_subscription_path(subscription),
+                      no_text: true,
+                      method: :post
+                  )
+                %>
+              <% end %>
             <% end %>
 
             <%= link_to_edit(subscription, no_text: true) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,11 +24,15 @@ en:
         successfully_canceled: Subscription Canceled!
         successfully_activated: Subscription Activated!
         successfully_skipped: Subscription delayed until %{date}
+        successfully_paused: Subscription Paused
+        successfully_resumed: Subscription Resumed
         actions:
           cancel: Cancel
           cancel_alert: "Are you sure you want to cancel this subscription?"
           activate: Activate
           skip: Skip One
+          pause: Pause
+          resume: Resume
         index:
           new_subscription: New Subscription
         edit:
@@ -127,5 +131,8 @@ en:
               inclusion: "is not a valid currency code"
             payment_source:
               not_owned_by_user: "does not belong to the user associated with the subscription"
+            paused:
+              cannot_skip: "cannot skip a subscription which is paused"
+              not_active: "cannot pause/resume a subscription which is not active"
             state:
               cannot_skip: cannot skip a subscription which is canceled or inactive

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,3 +127,5 @@ en:
               inclusion: "is not a valid currency code"
             payment_source:
               not_owned_by_user: "does not belong to the user associated with the subscription"
+            state:
+              cannot_skip: cannot skip a subscription which is canceled or inactive

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ SolidusSubscriptions::Engine.routes.draw do
         member do
           post :cancel
           post :skip
+          post :pause
+          post :resume
         end
       end
     end
@@ -19,9 +21,13 @@ Spree::Core::Engine.routes.draw do
 
   namespace :admin do
     resources :subscriptions, only: [:index, :new, :create, :edit, :update] do
-      delete :cancel, on: :member
-      post :activate, on: :member
-      post :skip, on: :member
+      member do
+        delete :cancel
+        post :activate
+        post :skip
+        post :pause
+        post :resume
+      end
       resources :installments, only: [:index, :show]
       resources :subscription_events, only: :index
       resources :subscription_orders, path: :orders, only: :index

--- a/db/migrate/20210905145955_add_paused_to_subscriptions.rb
+++ b/db/migrate/20210905145955_add_paused_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddPausedToSubscriptions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :solidus_subscriptions_subscriptions, :paused, :boolean, default: false
+  end
+end

--- a/lib/solidus_subscriptions/permission_sets/default_customer.rb
+++ b/lib/solidus_subscriptions/permission_sets/default_customer.rb
@@ -4,7 +4,7 @@ module SolidusSubscriptions
   module PermissionSets
     class DefaultCustomer < ::Spree::PermissionSets::Base
       def activate!
-        can [:show, :display, :update, :skip, :cancel], Subscription, ['user_id = ?', user.id] do |subscription, guest_token|
+        can [:show, :display, :update, :skip, :cancel, :pause, :resume], Subscription, ['user_id = ?', user.id] do |subscription, guest_token|
           (subscription.guest_token.present? && subscription.guest_token == guest_token) ||
             (subscription.user && subscription.user == user)
         end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -155,6 +155,865 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
     end
   end
 
+  describe '#pause' do
+    context 'when an active subscription is paused' do
+      it 'sets the paused column to true' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'active',
+          paused: false
+        )
+
+        subscription.pause
+
+        expect(subscription.reload.paused).to be_truthy
+      end
+
+      it 'does not change the state' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'active',
+          paused: false
+        )
+
+        subscription.pause
+
+        expect(subscription.reload.state).to eq('active')
+      end
+
+      it 'creates a paused event' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'active',
+          paused: false
+        )
+
+        subscription.pause
+
+        expect(subscription.events.last).to have_attributes(event_type: 'subscription_paused')
+      end
+
+      context 'when today is used as the actionable date' do
+        it 'sets actionable_date to the next day' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: Time.zone.today)
+
+          expect(subscription.reload.actionable_date).to eq(Time.zone.tomorrow)
+        end
+
+        it 'is not actionable' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: Time.zone.today)
+
+          expect(described_class.actionable).not_to include subscription
+        end
+
+        it 'pauses correctly' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: Time.zone.today)
+
+          aggregate_failures do
+            expect(subscription.reload.paused).to be_truthy
+            expect(subscription.state).to eq('active')
+          end
+        end
+
+        it 'creates a paused event' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: Time.zone.today)
+
+          expect(subscription.events.last).to have_attributes(event_type: 'subscription_paused')
+        end
+      end
+
+      context 'when a past date is used as the actionable date' do
+        it 'sets actionable_date to the next day' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: Time.zone.yesterday)
+
+          expect(subscription.reload.actionable_date).to eq(Time.zone.tomorrow)
+        end
+
+        it 'is not actionable' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: Time.zone.yesterday)
+
+          expect(described_class.actionable).not_to include subscription
+        end
+
+        it 'pauses correctly' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: Time.zone.yesterday)
+
+          aggregate_failures do
+            expect(subscription.reload.paused).to be_truthy
+            expect(subscription.state).to eq('active')
+          end
+        end
+
+        it 'creates a paused event' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: Time.zone.yesterday)
+
+          expect(subscription.events.last).to have_attributes(event_type: 'subscription_paused')
+        end
+      end
+
+      context 'when nil is used as the actionable date' do
+        it 'sets actionable_date to nil' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: nil)
+
+          expect(subscription.reload.actionable_date).to eq(nil)
+        end
+
+        it 'is not actionable' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: nil)
+
+          expect(described_class.actionable).not_to include subscription
+        end
+
+        it 'pauses correctly' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: nil)
+
+          aggregate_failures do
+            expect(subscription.reload.paused).to be_truthy
+            expect(subscription.state).to eq('active')
+          end
+        end
+
+        it 'creates a paused event' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: nil)
+
+          expect(subscription.events.last).to have_attributes(event_type: 'subscription_paused')
+        end
+      end
+
+      context 'when a future date is used as the actionable date' do
+        it 'sets actionable_date to the specified date' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: (Time.zone.tomorrow + 1.day))
+
+          expect(subscription.reload.actionable_date).to eq((Time.zone.tomorrow + 1.day))
+        end
+
+        it 'is not actionable' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: (Time.zone.tomorrow + 1.day))
+
+          expect(described_class.actionable).not_to include subscription
+        end
+
+        it 'pauses correctly' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: (Time.zone.tomorrow + 1.day))
+
+          aggregate_failures do
+            expect(subscription.reload.paused).to be_truthy
+            expect(subscription.state).to eq('active')
+          end
+        end
+
+        it 'creates a paused event' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: false
+          )
+
+          subscription.pause(actionable_date: (Time.zone.tomorrow + 1.day))
+
+          expect(subscription.events.last).to have_attributes(event_type: 'subscription_paused')
+        end
+      end
+
+      context 'when the actionable date has been reached' do
+        it 'is actionable' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.next_actionable_date
+
+          expect(described_class.actionable).to include subscription
+        end
+
+        it 'processes and resumes the subscription' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+          expected_date = Date.current + subscription.interval
+
+          SolidusSubscriptions::ProcessSubscriptionJob.perform_now(subscription)
+
+          aggregate_failures do
+            expect(subscription.reload.paused).to be_falsy
+            expect(subscription.actionable_date).to eq(expected_date)
+          end
+        end
+      end
+    end
+
+    context 'when a canceled subscription is paused' do
+      it 'adds an error when the method is called on a subscription which is not active' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'canceled',
+          paused: false
+        )
+
+        subscription.pause
+
+        expect(subscription.errors[:paused].first).to include 'not active'
+      end
+
+      it 'does not alter the subscription' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'canceled',
+          paused: false
+        )
+
+        expect { subscription.pause }.not_to(change { subscription.reload })
+      end
+
+      it 'does not create an event' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'canceled',
+          paused: false
+        )
+
+        subscription.pause
+
+        expect(subscription.events.last).not_to have_attributes(event_type: "subscription_paused")
+      end
+    end
+
+    context 'when a `pending_cancellation` subscription is paused' do
+      it 'adds an error when the method is called on a subscription which is not active' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'pending_cancellation',
+          paused: false
+        )
+
+        subscription.pause
+
+        expect(subscription.errors[:paused].first).to include 'not active'
+      end
+
+      it 'does not alter the subscription' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'pending_cancellation',
+          paused: false
+        )
+
+        expect { subscription.pause }.not_to(change { subscription.reload })
+      end
+
+      it 'does not create an event' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'pending_cancellation',
+          paused: true
+        )
+
+        subscription.pause
+
+        expect(subscription.events.last).not_to have_attributes(event_type: "subscription_paused")
+      end
+    end
+
+    context 'when an `inactive` subscription is paused' do
+      it 'adds an error when the method is called on a subscription which is not active' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'inactive',
+          paused: false
+        )
+
+        subscription.pause
+
+        expect(subscription.errors[:paused].first).to include 'not active'
+      end
+
+      it 'does not alter the subscription' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'inactive',
+          paused: false
+        )
+
+        expect { subscription.pause }.not_to(change { subscription.reload })
+      end
+
+      it 'does not create an event' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'inactive',
+          paused: false
+        )
+
+        subscription.pause
+
+        expect(subscription.events.last).not_to have_attributes(event_type: "subscription_paused")
+      end
+    end
+  end
+
+  describe '#resume' do
+    context 'when an active subscription is resumed' do
+      it 'sets the paused column to false' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'active',
+          paused: true
+        )
+
+        subscription.resume
+
+        expect(subscription.reload.paused).to be_falsy
+      end
+
+      it 'does not change the state' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'active',
+          paused: true
+        )
+
+        subscription.resume
+
+        expect(subscription.reload.state).to eq('active')
+      end
+
+      it 'creates a resumed event' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'active',
+          paused: true
+        )
+
+        subscription.resume
+
+        expect(subscription.events.last).to have_attributes(event_type: 'subscription_resumed')
+      end
+
+      context 'when a past date is used as the actionable date' do
+        it 'sets actionable_date to the next day' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: Time.zone.yesterday)
+
+          expect(subscription.reload.actionable_date).to eq(Time.zone.tomorrow)
+        end
+
+        it 'is not actionable' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: Time.zone.yesterday)
+
+          expect(described_class.actionable).not_to include subscription
+        end
+
+        it 'resumes correctly' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: Time.zone.yesterday)
+
+          aggregate_failures do
+            expect(subscription.reload.paused).to be_falsy
+            expect(subscription.state).to eq('active')
+          end
+        end
+
+        it 'creates a resumed event' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: Time.zone.yesterday)
+
+          expect(subscription.events.last).to have_attributes(event_type: 'subscription_resumed')
+        end
+      end
+
+      context 'when today is used as the actionable date' do
+        it 'sets actionable_date to the next day' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: Time.zone.today)
+
+          expect(subscription.reload.actionable_date).to eq(Time.zone.tomorrow)
+        end
+
+        it 'is not actionable' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: Time.zone.today)
+
+          expect(described_class.actionable).not_to include subscription
+        end
+
+        it 'resumes correctly' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: Time.zone.today)
+
+          aggregate_failures do
+            expect(subscription.reload.paused).to be_falsy
+            expect(subscription.state).to eq('active')
+          end
+        end
+
+        it 'creates a resumed event' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: Time.zone.today)
+
+          expect(subscription.events.last).to have_attributes(event_type: 'subscription_resumed')
+        end
+      end
+
+      context 'when nil is used as the actionable date' do
+        it 'sets actionable_date to the next day' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: nil)
+
+          expect(subscription.reload.actionable_date).to eq(Time.zone.tomorrow)
+        end
+
+        it 'is not actionable' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: nil)
+
+          expect(described_class.actionable).not_to include subscription
+        end
+
+        it 'resumes correctly' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: nil)
+
+          aggregate_failures do
+            expect(subscription.reload.paused).to be_falsy
+            expect(subscription.state).to eq('active')
+          end
+        end
+
+        it 'creates a resumed event' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: nil)
+
+          expect(subscription.events.last).to have_attributes(event_type: 'subscription_resumed')
+        end
+      end
+
+      context 'when a future date is used as the actionable date' do
+        it 'sets actionable_date to the specified date' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: (Time.zone.tomorrow + 1.day))
+
+          expect(subscription.reload.actionable_date).to eq((Time.zone.tomorrow + 1.day))
+        end
+
+        it 'is not actionable' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: (Time.zone.tomorrow + 1.day))
+
+          expect(described_class.actionable).not_to include subscription
+        end
+
+        it 'resumes correctly' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: (Time.zone.tomorrow + 1.day))
+
+          aggregate_failures do
+            expect(subscription.reload.paused).to be_falsy
+            expect(subscription.state).to eq('active')
+          end
+        end
+
+        it 'creates a resumed event' do
+          subscription = create(
+            :subscription,
+            :actionable,
+            :with_shipping_address,
+            state: 'active',
+            paused: true
+          )
+
+          subscription.resume(actionable_date: (Time.zone.tomorrow + 1.day))
+
+          expect(subscription.events.last).to have_attributes(event_type: 'subscription_resumed')
+        end
+      end
+    end
+
+    context 'when a `canceled` subscription is resumed' do
+      it 'does not alter the subscription' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'canceled',
+          paused: true
+        )
+
+        expect { subscription.resume }.not_to(change { subscription.reload })
+      end
+
+      it 'does not create an event' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'canceled',
+          paused: true
+        )
+
+        subscription.resume
+
+        expect(subscription.events.last).not_to have_attributes(event_type: "subscription_resumed")
+      end
+    end
+
+    context 'when a `pending_cancellation` subscription is resumed' do
+      it 'does not alter the subscription' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'pending_cancellation',
+          paused: true
+        )
+
+        expect { subscription.resume }.not_to(change { subscription.reload })
+      end
+
+      it 'does not create an event' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'pending_cancellation',
+          paused: true
+        )
+
+        subscription.resume
+
+        expect(subscription.events.last).not_to have_attributes(event_type: "subscription_resumed")
+      end
+    end
+
+    context 'when an `inactive` subscription is resumed' do
+      it 'does not alter the subscription' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'inactive',
+          paused: true
+        )
+
+        expect { subscription.resume }.not_to(change { subscription.reload })
+      end
+
+      it 'does not create an event' do
+        subscription = create(
+          :subscription,
+          :actionable,
+          :with_shipping_address,
+          state: 'inactive',
+          paused: true
+        )
+
+        subscription.resume
+
+        expect(subscription.events.last).not_to have_attributes(event_type: "subscription_resumed")
+      end
+    end
+  end
+
+  describe '#state_with_pause' do
+    it 'returns `paused` when the subscription is active and paused' do
+      subscription = create(
+        :subscription,
+        :with_shipping_address,
+        paused: true,
+        state: 'active'
+      )
+
+      expect(subscription.state_with_pause).to eq('paused')
+    end
+
+    it 'returns `active` when the subscription is active and not paused' do
+      subscription = create(
+        :subscription,
+        :with_shipping_address,
+        paused: false,
+        state: 'active'
+      )
+
+      expect(subscription.state_with_pause).to eq('active')
+    end
+
+    it 'returns `canceled` when the subscription is canceled and not paused' do
+      subscription = create(
+        :subscription,
+        :with_shipping_address,
+        paused: false,
+        state: 'canceled'
+      )
+
+      expect(subscription.state_with_pause).to eq('canceled')
+    end
+  end
+
   describe '#skip' do
     subject { subscription.skip&.to_date }
 


### PR DESCRIPTION
## Summary

This change:

- Adds the ability to pause subscriptions for either a specified amount of time or an indefinite amount of time
- Adds endpoints to pause and resume subscriptions
- Integrates pause/resume buttons on the subscription admin page

## How

Adds a `paused` boolean column to the `subscriptions` table.
  - The `paused` attribute acts as a sub-state of `active`. This is a logical approach because `paused` subscriptions should still be considered `active`.

Subscriptions can be paused with a scheduled activation (corresponding to the `actionable_date`) or indefinitely (set the `actionable_date` to `nil`).
  - The soonest allowed actionable date (for pausing and resuming) is the next day to avoid issues with processing subscriptions
  - Subscriptions can also be resumed with a scheduled activation or immediately (next day)




**Additional note:** Credit for implementation goes to @ikraamg and @rainerdema I just extended their work for this PR.

