### PR TITLE
Bugfix update column when pausing

### DIFF
--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -38,7 +38,7 @@ module SolidusSubscriptions
     before_validation :set_currency
     before_create :generate_guest_token
     after_create :emit_event_for_creation
-    before_update :update_actionable_date_if_interval_changed
+    before_update :update_actionable_date_if_interval_changed, unless: :paused_changed?
     after_update :emit_events_for_update
 
     # Find all subscriptions that are "actionable"; that is, ones that have an
@@ -220,7 +220,7 @@ module SolidusSubscriptions
       return false if errors.any?
       return true if paused?
 
-      result = update_columns paused: true, actionable_date: actionable_date && tomorrow_or_after(actionable_date)
+      result = update! paused: true, actionable_date: actionable_date && tomorrow_or_after(actionable_date)
       create_and_emit_event(type: 'subscription_paused') if result
       result
     end
@@ -230,7 +230,7 @@ module SolidusSubscriptions
       return false if errors.any?
       return true unless paused?
 
-      result = update_columns paused: false, actionable_date: tomorrow_or_after(actionable_date)
+      result = update! paused: false, actionable_date: tomorrow_or_after(actionable_date)
       create_and_emit_event(type: 'subscription_resumed') if result
       result
     end

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -466,13 +466,14 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
             state: 'active',
             paused: true
           )
-          expected_date = Date.current + subscription.interval
+          expected_actionable_date = subscription.actionable_date + subscription.interval
 
           SolidusSubscriptions::ProcessSubscriptionJob.perform_now(subscription)
 
           aggregate_failures do
             expect(subscription.reload.paused).to be_falsy
-            expect(subscription.actionable_date).to eq(expected_date)
+            expect(subscription.installments.last.created_at).to be_within(1.hour).of(Time.zone.now)
+            expect(subscription.actionable_date).to eq(expected_actionable_date)
           end
         end
       end


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/solidusio-contrib/solidus_subscriptions/commit/afbffbf65c2be3cd049b5cbd47c6de1d22c88554 where `update_columns` is used instead of `update!` when pausing and unpausing a subscription. This causes issues because `updated_at` does not change, and callbacks created in user applications will not run. 

Also improves a test for when the paused `actionable_date` is reached.