### PR TITLE
Improve subscription generator

### DIFF
--- a/app/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions.rb
+++ b/app/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions.rb
@@ -9,11 +9,7 @@ module SolidusSubscriptions
     module Order
       module FinalizeCreatesSubscriptions
         def finalize!
-          SolidusSubscriptions::SubscriptionGenerator.group(subscription_line_items).each do |line_items|
-            SolidusSubscriptions::SubscriptionGenerator.activate(line_items)
-          end
-
-          reload
+          SolidusSubscriptions::SubscriptionGenerator.from_order(self)
 
           super
         end

--- a/spec/lib/solidus_subscriptions/subscription_generator_spec.rb
+++ b/spec/lib/solidus_subscriptions/subscription_generator_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
     it 'creates subscriptions with the correct attributes', :aggregate_failures do
       subscription_line_items = build_list(:subscription_line_item, 2)
       subscription_line_item = subscription_line_items.first
+      order = subscription_line_item.order
 
-      subscription = described_class.activate(subscription_line_items)
+      subscription = described_class.activate(subscription_line_items, order: order)
 
       expect(subscription.line_items).to match_array(subscription_line_items)
       expect(subscription).to have_attributes(
@@ -33,6 +34,7 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
 
     it 'copies the payment method from the order' do
       subscription_line_item = build(:subscription_line_item)
+      order = subscription_line_item.order
       payment_method = create(:credit_card_payment_method)
       payment_source = create(:credit_card, payment_method: payment_method, user: subscription_line_item.order.user)
       create(:payment,
@@ -40,7 +42,7 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
         source: payment_source,
         payment_method: payment_method,)
 
-      subscription = described_class.activate([subscription_line_item])
+      subscription = described_class.activate([subscription_line_item], order: order)
 
       expect(subscription).to have_attributes(
         payment_method: payment_method,
@@ -51,8 +53,9 @@ RSpec.describe SolidusSubscriptions::SubscriptionGenerator do
     it 'cleanups the subscription line items fields duplicated on the subscription' do
       attrs = { interval_length: 2, interval_units: :week, end_date: Time.zone.tomorrow }
       subscription_line_item = create(:subscription_line_item, attrs)
+      order = subscription_line_item.order
 
-      described_class.activate([subscription_line_item])
+      described_class.activate([subscription_line_item], order: order)
 
       expect(subscription_line_item.reload).to have_attributes(
         interval_length: nil,

--- a/spec/models/solidus_subscriptions/subscription_spec.rb
+++ b/spec/models/solidus_subscriptions/subscription_spec.rb
@@ -1020,12 +1020,12 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
 
     let(:total_skips) { 0 }
     let(:successive_skips) { 0 }
-    let(:expected_date) { 2.months.from_now.to_date }
 
     let(:subscription) do
       create(
         :subscription,
         :with_line_item,
+        actionable_date: Time.zone.today + 1.month,
         skip_count: total_skips,
         successive_skip_count: successive_skips
       )
@@ -1064,7 +1064,13 @@ RSpec.describe SolidusSubscriptions::Subscription, type: :model do
     end
 
     context 'when the subscription can be skipped' do
-      it { is_expected.to eq expected_date }
+      it 'skips correctly based on the subscription interval' do
+        expected_actionable_date = subscription.actionable_date + subscription.interval
+
+        subject
+
+        expect(subscription.actionable_date).to eq(expected_actionable_date)
+      end
 
       it 'creates a subscription_skipped event' do
         subject


### PR DESCRIPTION
Improves the subscription generator implementation and simplifies the `finalize!` method prepended to `Spree::Order` by:

- Introducing a `from_order` method in `SubscriptionGenerator`
  - Calling `from_order` and passing self in `Spree::Order` `finalize!`
- Rewrite the `SubscriptionGenerator` implementation to be more maintainable and easier to modify.
  - Change `SubscriptionGenerator` to a class with class methods that internally use the `SubscriptionGenerator` class to create subscriptions (that's a mouthful 😅).
- Use the user wallet as a backup payment source when a `Spree::Order` has no payments (in the case of free orders).
  -  Extracting this into `find_payment_source` also makes it easier for decorators to modify this method for specific use cases.

Unrelated:
- Fix flaky skip spec

**Note:** The issue with the specs also appears to be present on master.