### PR TITLE
Make the subscription generator a configurable class

### DIFF
--- a/app/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions.rb
+++ b/app/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions.rb
@@ -8,21 +8,16 @@ module SolidusSubscriptions
   module Spree
     module Order
       module FinalizeCreatesSubscriptions
-        def self.finalize_method
-          if Gem::Version.new(::Spree.solidus_version) >= Gem::Version.new('3.2.0.alpha')
-            :finalize
-          else
-            :finalize!
-          end
-        end
+        method_name = Spree::Order.instance_methods.include?(:finalize) ? :finalize : :finalize!
 
-        define_method finalize_method do
+        define_method(method_name) do
           SolidusSubscriptions::SubscriptionGenerator.call(self)
           super()
         end
+
+        ::Spree::Order.prepend self
       end
     end
   end
 end
 
-Spree::Order.prepend(SolidusSubscriptions::Spree::Order::FinalizeCreatesSubscriptions)

--- a/app/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions.rb
+++ b/app/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions.rb
@@ -11,7 +11,7 @@ module SolidusSubscriptions
         method_name = Spree::Order.instance_methods.include?(:finalize) ? :finalize : :finalize!
 
         define_method(method_name) do
-          SolidusSubscriptions::SubscriptionGenerator.call(self)
+          SolidusSubscriptions.configuration.subscription_generator_class.call(self)
           super()
         end
 
@@ -20,4 +20,3 @@ module SolidusSubscriptions
     end
   end
 end
-

--- a/app/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions.rb
+++ b/app/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions.rb
@@ -17,12 +17,7 @@ module SolidusSubscriptions
         end
 
         define_method finalize_method do
-          SolidusSubscriptions::SubscriptionGenerator.group(subscription_line_items).each do |line_items|
-            SolidusSubscriptions::SubscriptionGenerator.activate(line_items)
-          end
-
-          reload
-
+          SolidusSubscriptions::SubscriptionGenerator.call(self)
           super()
         end
       end

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -3,15 +3,27 @@
 module SolidusSubscriptions
   class Configuration
     attr_accessor(
-      :maximum_total_skips, :maximum_reprocessing_time, :churn_buster_account_id,
-      :churn_buster_api_key, :clear_past_installments
+      :churn_buster_account_id,
+      :churn_buster_api_key,
+      :clear_past_installments,
+      :maximum_reprocessing_time,
+      :maximum_total_skips,
     )
 
     attr_writer(
-      :success_dispatcher_class, :failure_dispatcher_class, :payment_failed_dispatcher_class,
-      :out_of_stock_dispatcher, :maximum_successive_skips, :reprocessing_interval,
-      :minimum_cancellation_notice, :processing_queue, :subscription_line_item_attributes,
-      :subscription_attributes, :subscribable_class, :order_creator_class, :processing_error_handler
+      :failure_dispatcher_class,
+      :maximum_successive_skips,
+      :minimum_cancellation_notice,
+      :order_creator_class,
+      :out_of_stock_dispatcher,
+      :payment_failed_dispatcher_class,
+      :processing_error_handler,
+      :processing_queue,
+      :reprocessing_interval,
+      :subscribable_class,
+      :subscription_attributes,
+      :subscription_line_item_attributes,
+      :success_dispatcher_class,
     )
 
     def success_dispatcher_class

--- a/lib/solidus_subscriptions/configuration.rb
+++ b/lib/solidus_subscriptions/configuration.rb
@@ -22,9 +22,15 @@ module SolidusSubscriptions
       :reprocessing_interval,
       :subscribable_class,
       :subscription_attributes,
+      :subscription_generator_class,
       :subscription_line_item_attributes,
       :success_dispatcher_class,
     )
+
+    def subscription_generator_class
+      @subscription_generator_class ||= 'SolidusSubscriptions::SubscriptionGenerator'
+      @subscription_generator_class.constantize
+    end
 
     def success_dispatcher_class
       @success_dispatcher_class ||= 'SolidusSubscriptions::Dispatcher::SuccessDispatcher'

--- a/lib/solidus_subscriptions/subscription_generator.rb
+++ b/lib/solidus_subscriptions/subscription_generator.rb
@@ -8,6 +8,12 @@ module SolidusSubscriptions
 
     SubscriptionConfiguration = Struct.new(:interval_length, :interval_units, :end_date)
 
+    def call(order)
+      group(order.subscription_line_items).each { |line_items| activate(line_items) }
+
+      order.reload
+    end
+
     # Create and persist a subscription for a collection of subscription
     #   line items
     #

--- a/spec/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions_spec.rb
+++ b/spec/decorators/models/solidus_subscriptions/spree/order/finalize_creates_subscriptions_spec.rb
@@ -4,7 +4,9 @@ require 'spec_helper'
 
 RSpec.describe SolidusSubscriptions::Spree::Order::FinalizeCreatesSubscriptions do
   describe '#finalize' do
-    subject(:finalize) { order.send(described_class.finalize_method) }
+    subject(:finalize) do
+      order.send(Spree::Order.instance_methods.include?(:finalize) ? :finalize : :finalize!)
+    end
 
     let(:order) { create :order, :with_subscription_line_items }
     let(:subscription_line_item) { order.subscription_line_items.last }


### PR DESCRIPTION
Adds `SolidusSubscriptions.configuration.subscription_generator_class` as a callable that takes in an order instead of passing line items so that the generator can use a custom strategy.